### PR TITLE
Stop timer and provide message

### DIFF
--- a/src/csv_handler/CSVHandler.py
+++ b/src/csv_handler/CSVHandler.py
@@ -43,15 +43,14 @@ class CSVHandler:
 
         return current_time
 
-    def finish_created_entry(self) -> str:
+    def finish_created_entry(self, message: str) -> str:
         stop_time = datetime.now().strftime("%b, %d %Y at %H:%M:%S")
 
         data = pandas.read_csv(self.tracker_file, dtype=str)
 
         index = len(data) - 1
         data.at[index, "stop_time"] = stop_time
-        # TODO: Add message
-        # data["message"][0] = ""
+        data.at[index, "message"] = message
 
         data.to_csv(self.tracker_file, index=False)
 

--- a/src/csv_handler/CSVHandler.py
+++ b/src/csv_handler/CSVHandler.py
@@ -42,3 +42,17 @@ class CSVHandler:
             data.to_csv(f, header=False, index=False)
 
         return current_time
+
+    def finish_created_entry(self) -> str:
+        stop_time = datetime.now().strftime("%b, %d %Y at %H:%M:%S")
+
+        data = pandas.read_csv(self.tracker_file, dtype=str)
+
+        index = len(data) - 1
+        data.at[index, "stop_time"] = stop_time
+        # TODO: Add message
+        # data["message"][0] = ""
+
+        data.to_csv(self.tracker_file, index=False)
+
+        return stop_time

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import click
 from .Tracker import Tracker
 from .status import status
 from .start import start
+from .stop import stop
 
 
 def enable_logging_in_console():
@@ -37,6 +38,7 @@ if __name__ == "__main__":
     # Add subcommands
     cli.add_command(status.status)
     cli.add_command(start.start)
+    cli.add_command(stop.stop)
 
     # Start click
     cli()

--- a/src/stop/stop.py
+++ b/src/stop/stop.py
@@ -6,10 +6,14 @@ from ..csv_handler import CSVHandler
 
 
 @click.command()
-def stop():
+@click.option("--message", "-m", default="", type=str)
+def stop(message: str) -> None:
     """Stop an exisiting timer"""
     csv_handler = CSVHandler.CSVHandler()
-    time = csv_handler.finish_created_entry()
+    time = csv_handler.finish_created_entry(message)
 
     logging.info("Existing timer stopped")
-    print(f"Existing timer stopped at {time}\nOK")
+    if message:
+        print(f"Existing timer stopped at {time} with message\nOK")
+    else:
+        print(f"Existing timer stopped at {time}\nOK")

--- a/src/stop/stop.py
+++ b/src/stop/stop.py
@@ -1,0 +1,15 @@
+import logging
+
+import click
+
+from ..csv_handler import CSVHandler
+
+
+@click.command()
+def stop():
+    """Stop an exisiting timer"""
+    csv_handler = CSVHandler.CSVHandler()
+    time = csv_handler.finish_created_entry()
+
+    logging.info("Existing timer stopped")
+    print(f"Existing timer stopped at {time}\nOK")

--- a/tests/test_csv_handler/test_csv_handler.py
+++ b/tests/test_csv_handler/test_csv_handler.py
@@ -14,7 +14,7 @@ class TestCSVHandler(unittest.TestCase):
             "\w{3}, \d{2} \d{4} at (\d{2}:){2}\d{2}"
         )
 
-    def test_inititalizing_tracker_file(self):
+    def test_inititalizing_tracker_file(self) -> None:
         self.clean_and_init_tracker_file()
         self.assertTrue(self.columns_names_are_correct())
 
@@ -22,7 +22,7 @@ class TestCSVHandler(unittest.TestCase):
         column_names = self.get_column_names()
         return column_names == ["start_time", "stop_time", "message"]
 
-    def test_creating_a_new_entry(self):
+    def test_creating_a_new_entry(self) -> None:
         self.clean_and_init_tracker_file()
         self.csv_handler.create_new_entry()
 
@@ -37,21 +37,40 @@ class TestCSVHandler(unittest.TestCase):
         self.assertEqual(file["stop_time"][0], "")
         self.assertEqual(file["message"][0], "")
 
-    def test_checking_if_tracker_file_exists(self):
+    def test_finishing_a_created_entry(self) -> None:
+        self.clean_and_init_tracker_file()
+        start_time = self.csv_handler.create_new_entry()
+        stop_time = self.csv_handler.finish_created_entry()
+
+        # Check for the column names
+        self.assertTrue(self.columns_names_are_correct())
+
+        file = self.get_contents_of_tracker_file()
+        # Replace pandas 'nan' with an empty string for simple assertions
+        file = file.fillna("")
+
+        self.assertTrue(self.datetime_pattern.match(file["start_time"][0]))
+        self.assertTrue(self.datetime_pattern.match(file["stop_time"][0]))
+
+        self.assertEqual(file["start_time"][0], start_time)
+        self.assertEqual(file["stop_time"][0], stop_time)
+        self.assertEqual(file["message"][0], "")
+
+    def test_checking_if_tracker_file_exists(self) -> None:
         self.remove_tracker_file()
         self.assertFalse(self.csv_handler.tracker_file_exists())
 
         self.csv_handler.create_tracker_file()
         self.assertTrue(self.csv_handler.tracker_file_exists())
 
-    def remove_tracker_file(self):
+    def remove_tracker_file(self) -> None:
         try:
             os.remove(self.csv_handler.tracker_file)
         except FileNotFoundError:
             # File is not existing, that's good, nothing to do for us.
             pass
 
-    def clean_and_init_tracker_file(self):
+    def clean_and_init_tracker_file(self) -> None:
         self.remove_tracker_file()
         self.csv_handler.init_tracker_csv_file()
 

--- a/tests/test_csv_handler/test_csv_handler.py
+++ b/tests/test_csv_handler/test_csv_handler.py
@@ -37,10 +37,19 @@ class TestCSVHandler(unittest.TestCase):
         self.assertEqual(file["stop_time"][0], "")
         self.assertEqual(file["message"][0], "")
 
-    def test_finishing_a_created_entry(self) -> None:
+    def test_finishing_a_created_entry_with_empty_message(self) -> None:
+        message = ""
+        self.finishing_a_created_entry(message)
+
+    def test_finishing_a_created_entry_with_message(self) -> None:
+        message = "Developed new feature for Tracker"
+        self.finishing_a_created_entry(message)
+
+    def finishing_a_created_entry(self, message: str) -> None:
         self.clean_and_init_tracker_file()
+
         start_time = self.csv_handler.create_new_entry()
-        stop_time = self.csv_handler.finish_created_entry()
+        stop_time = self.csv_handler.finish_created_entry(message)
 
         # Check for the column names
         self.assertTrue(self.columns_names_are_correct())
@@ -54,7 +63,7 @@ class TestCSVHandler(unittest.TestCase):
 
         self.assertEqual(file["start_time"][0], start_time)
         self.assertEqual(file["stop_time"][0], stop_time)
-        self.assertEqual(file["message"][0], "")
+        self.assertEqual(file["message"][0], message)
 
     def test_checking_if_tracker_file_exists(self) -> None:
         self.remove_tracker_file()


### PR DESCRIPTION
Makes it possible to stop a timer by typing `tracker stop`. Save the time at which the timer was stopped to the entry of the started timer.
Add a description of the done work by typing `tracker stop -m "<your-message>"`. This will stop the timer, save the time at which the timer was stopped and add the description to this entry.

- [X] Test verifying change added.
- [X] Logging message added.