### PR TITLE
Show entries of specific day by ID

### DIFF
--- a/src/commands/log/log.py
+++ b/src/commands/log/log.py
@@ -3,6 +3,7 @@ import sys
 import click
 
 from src.console_logger.console_logger import info, warn
+from src.handler.entry_handler import GroupedEntryHandler
 from src.handler.entry_handler import EntryHandler
 from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
 
@@ -29,7 +30,7 @@ def log(id_of_date: int):
         info(f"Showing all entries of {date}. ({number_of_entries} in total).\n")
         info(f"{entries_of_specific_date}\n")
     else:
-        entry_handler = EntryHandler.EntryHandler()
+        entry_handler = GroupedEntryHandler.GroupedEntryHandler()
         entries_grouped_by_date = entry_handler.get_entries_grouped_by_date()
         number_of_grouped_entries = len(entries_grouped_by_date)
 

--- a/src/commands/log/log.py
+++ b/src/commands/log/log.py
@@ -28,7 +28,8 @@ def log(id_of_date: int):
         number_of_entries = len(entries_of_specific_date)
 
         info(f"Showing all entries of {date}. ({number_of_entries} in total).\n")
-        info(f"{entries_of_specific_date}\n")
+        info(f"{entries_of_specific_date}\n"
+             f"\nOK")
     else:
         entry_handler = GroupedEntryHandler.GroupedEntryHandler()
         entries_grouped_by_date = entry_handler.get_entries_grouped_by_date()
@@ -40,4 +41,5 @@ def log(id_of_date: int):
         else:
             info(f"Showing all entries grouped by date. ({number_of_grouped_entries} in total).\n"
                  f"Use \"tracker log <ID>\" to show all entries of the date with the ID <ID>.\n")
-            info(f"{entries_grouped_by_date}\n")
+            info(f"{entries_grouped_by_date}\n"
+                 f"\nOK")

--- a/src/commands/log/log.py
+++ b/src/commands/log/log.py
@@ -26,12 +26,8 @@ def log(id_of_date: int):
 
         number_of_entries = len(entries_of_specific_date)
 
-        if number_of_entries == 0:
-            info("Nothing to see yet.\n"
-                 "Start creating entries by typing \"tracker start\" and finish them by typing \"tracker stop\".")
-        else:
-            info(f"Showing all entries of {date}. ({number_of_entries} in total).\n")
-            info(f"{entries_of_specific_date}\n")
+        info(f"Showing all entries of {date}. ({number_of_entries} in total).\n")
+        info(f"{entries_of_specific_date}\n")
     else:
         entry_handler = EntryHandler.EntryHandler()
         entries_grouped_by_date = entry_handler.get_entries_grouped_by_date()

--- a/src/commands/log/log.py
+++ b/src/commands/log/log.py
@@ -5,16 +5,33 @@ from src.handler.entry_handler import EntryHandler
 
 
 @click.command()
-def log():
+@click.option("-i", "--id", "id_of_date", help="ID of a specific day", type=int)
+def log(id_of_date: int):
     """Show old entries grouped by date"""
-    entry_handler = EntryHandler.EntryHandler()
-    entries_grouped_by_date = entry_handler.get_entries_grouped_by_date()
-    number_of_grouped_entries = len(entries_grouped_by_date)
+    if id_of_date:
+        entry_handler = EntryHandler.EntryHandler()
+        entries_of_specific_date = entry_handler.get_entries_of_specific_date(id_of_date)
 
-    if number_of_grouped_entries == 0:
-        info("Nothing to see yet.\n"
-             "Start creating entries by typing \"tracker start\" and finish them by typing \"tracker stop\".")
+        date = entries_of_specific_date[0]
+        entries_of_specific_date = entries_of_specific_date[1]
+
+        number_of_entries = len(entries_of_specific_date)
+
+        if number_of_entries == 0:
+            info("Nothing to see yet.\n"
+                 "Start creating entries by typing \"tracker start\" and finish them by typing \"tracker stop\".")
+        else:
+            info(f"Showing all entries of {date}. ({number_of_entries} in total).\n")
+            info(f"{entries_of_specific_date}\n")
     else:
-        info(f"Showing all entries grouped by date. ({number_of_grouped_entries} in total).\n"
-             f"Use \"tracker log <ID>\" to show all entries of the date with the ID <ID>.\n")
-        info(f"{entries_grouped_by_date}\n")
+        entry_handler = EntryHandler.EntryHandler()
+        entries_grouped_by_date = entry_handler.get_entries_grouped_by_date()
+        number_of_grouped_entries = len(entries_grouped_by_date)
+
+        if number_of_grouped_entries == 0:
+            info("Nothing to see yet.\n"
+                 "Start creating entries by typing \"tracker start\" and finish them by typing \"tracker stop\".")
+        else:
+            info(f"Showing all entries grouped by date. ({number_of_grouped_entries} in total).\n"
+                 f"Use \"tracker log <ID>\" to show all entries of the date with the ID <ID>.\n")
+            info(f"{entries_grouped_by_date}\n")

--- a/src/commands/log/log.py
+++ b/src/commands/log/log.py
@@ -1,16 +1,25 @@
+import sys
+
 import click
 
-from src.console_logger.console_logger import info
+from src.console_logger.console_logger import info, warn
 from src.handler.entry_handler import EntryHandler
+from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
 
 
 @click.command()
 @click.option("-i", "--id", "id_of_date", help="ID of a specific day", type=int)
 def log(id_of_date: int):
     """Show old entries grouped by date"""
-    if id_of_date:
+    if id_of_date is not None:
         entry_handler = EntryHandler.EntryHandler()
-        entries_of_specific_date = entry_handler.get_entries_of_specific_date(id_of_date)
+        try:
+            entries_of_specific_date = entry_handler.get_entries_of_specific_date(id_of_date)
+        except InvalidIDOfDateException:
+            warn(f"We couldn't find a date matching the ID {id_of_date}.\n"
+                 f"Please double check if this was the ID you meant.\n"
+                 f"EXIT")
+            sys.exit(-1)
 
         date = entries_of_specific_date[0]
         entries_of_specific_date = entries_of_specific_date[1]

--- a/src/commands/status/status.py
+++ b/src/commands/status/status.py
@@ -3,7 +3,7 @@ import click
 
 from src.console_logger.console_logger import info
 from src.handler.timer_handler.TimerHandler import TimerHandler
-from src.handler.entry_handler.EntryHandler import EntryHandler
+from src.handler.entry_handler.GroupedEntryHandler import GroupedEntryHandler
 
 
 @click.command()
@@ -11,7 +11,7 @@ def status():   # pragma: no cover
     """Provide information about the current tracking process"""
     # TODO: Add real information
     timer_handler = TimerHandler()
-    entry_handler = EntryHandler()
+    entry_handler = GroupedEntryHandler()
 
     unfinished_entries_present = timer_handler.unfinished_entry_present()
     number_of_entries = len(entry_handler.get_data())

--- a/src/exceptions/InvalidIDOfDateException.py
+++ b/src/exceptions/InvalidIDOfDateException.py
@@ -1,0 +1,2 @@
+class InvalidIDOfDateException(Exception):
+    pass

--- a/src/handler/entry_handler/BaseEntryHandlerClass.py
+++ b/src/handler/entry_handler/BaseEntryHandlerClass.py
@@ -20,6 +20,3 @@ class BaseEntryHandlerClass(CSVAttributes):
     def group_entries_by_date(self) -> pandas.DataFrame:
         data_grouped_by_date = self.data.groupby("start_date", as_index=False)
         return data_grouped_by_date
-
-    def boost_index(self) -> None:
-        self.data.index += 1

--- a/src/handler/entry_handler/BaseEntryHandlerClass.py
+++ b/src/handler/entry_handler/BaseEntryHandlerClass.py
@@ -1,0 +1,25 @@
+import pandas
+
+from src.csv.CSVAttributes import CSVAttributes
+
+
+class BaseEntryHandlerClass(CSVAttributes):
+    def __init__(self):
+        super(BaseEntryHandlerClass, self).__init__()
+
+        self.data = None
+
+    def get_data(self) -> pandas.DataFrame:
+        data = pandas.read_csv(self.tracker_file, header=0)
+
+        # Change this column to a time type for allowing summing up the total work hours later
+        data["work_hours"] = pandas.to_timedelta(data.work_hours)
+
+        return data.fillna("")
+
+    def group_entries_by_date(self) -> pandas.DataFrame:
+        data_grouped_by_date = self.data.groupby("start_date", as_index=False)
+        return data_grouped_by_date
+
+    def boost_index(self) -> None:
+        self.data.index += 1

--- a/src/handler/entry_handler/EntryHandler.py
+++ b/src/handler/entry_handler/EntryHandler.py
@@ -9,6 +9,34 @@ class EntryHandler(CSVAttributes):
 
         self.data = None
 
+    def get_entries_of_specific_date(self, id_of_date: int) -> list:
+        entries_grouped_by_date = self.get_entries_grouped_by_date()
+        date = entries_grouped_by_date.at[id_of_date, "Date"]
+
+        self.data = self.get_data()
+        self.data = self.group_entries_by_date()
+
+        entries_of_date_at_index: pandas.DataFrame = self.data.get_group(date)
+        entries_of_date_at_index.reset_index()
+        entries_of_date_at_index.index += 1
+
+        entries_of_date_at_index = entries_of_date_at_index \
+            .rename(columns={
+                                "start_date": "Start Date", "start_time": "Start Time",
+                                "stop_date": "Stop Date", "stop_time": "Stop Time",
+                                "work_hours": "Work hours", "message": "Message"
+                            }
+                    )
+        entries_of_date_at_index["Start"] = entries_of_date_at_index[["Start Date", "Start Time"]].apply(lambda x: " at ".join(x), axis=1)
+        entries_of_date_at_index["Stop"] = entries_of_date_at_index[["Stop Date", "Stop Time"]].apply(lambda x: " at ".join(x), axis=1)
+
+        entries_of_date_at_index = entries_of_date_at_index.drop(columns=["Start Date", "Start Time", "Stop Date", "Stop Time"])
+        entries_of_date_at_index = entries_of_date_at_index[["Start", "Stop", "Work hours", "Message"]]
+
+        pandas.set_option("display.max_colwidth", None)
+
+        return [date, entries_of_date_at_index]
+
     def get_entries_grouped_by_date(self) -> pandas.DataFrame:
         self.data = self.get_data()
 

--- a/src/handler/entry_handler/EntryHandler.py
+++ b/src/handler/entry_handler/EntryHandler.py
@@ -22,8 +22,8 @@ class EntryHandler(BaseEntryHandlerClass):
         self.data = self.group_entries_by_date()
 
         self.entries = self.data.get_group(date)
-        self.change_index()
 
+        self.change_index()
         self.merge_date_and_time_columns()
 
         self.remove_start_and_stop_date_and_start_and_stop_time_columns()

--- a/src/handler/entry_handler/EntryHandler.py
+++ b/src/handler/entry_handler/EntryHandler.py
@@ -2,6 +2,7 @@ import pandas
 
 from src.csv.CSVAttributes import CSVAttributes
 from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
+from src.handler.entry_handler.GroupedEntryHandler import GroupedEntryHandler
 
 
 class EntryHandler(CSVAttributes):
@@ -9,18 +10,19 @@ class EntryHandler(CSVAttributes):
         super(EntryHandler, self).__init__()
 
         self.data = None
+        self.grouped_entry_handler = GroupedEntryHandler()
 
     def get_entries_of_specific_date(self, id_of_date: int) -> list:
-        entries_grouped_by_date = self.get_entries_grouped_by_date()
+        entries_grouped_by_date = self.grouped_entry_handler.get_entries_grouped_by_date()
         try:
             date = entries_grouped_by_date.at[id_of_date, "Date"]
         except KeyError:
             raise InvalidIDOfDateException
 
-        self.data = self.get_data()
-        self.data = self.group_entries_by_date()
+        self.grouped_entry_handler.data = self.grouped_entry_handler.get_data()
+        self.grouped_entry_handler.data = self.grouped_entry_handler.group_entries_by_date()
 
-        entries_of_date_at_index: pandas.DataFrame = self.data.get_group(date)
+        entries_of_date_at_index: pandas.DataFrame = self.grouped_entry_handler.data.get_group(date)
         entries_of_date_at_index.reset_index()
         entries_of_date_at_index.index += 1
 
@@ -40,59 +42,3 @@ class EntryHandler(CSVAttributes):
         pandas.set_option("display.max_colwidth", None)
 
         return [date, entries_of_date_at_index]
-
-    def get_entries_grouped_by_date(self) -> pandas.DataFrame:
-        self.data = self.get_data()
-
-        self.data = self.group_entries_by_date()
-        self.data = self.sum_work_hours_up()
-        self.data = self.rename_columns()
-
-        self.change_index()
-
-        self.data = self.reorder_entries_from_the_latest_down_to_the_oldest_one()
-
-        return self.data
-
-    def get_data(self) -> pandas.DataFrame:
-        data = pandas.read_csv(self.tracker_file, header=0)
-
-        # Change this column to a time type for allowing summing up the total work hours later
-        data["work_hours"] = pandas.to_timedelta(data.work_hours)
-
-        return data.fillna("")
-
-    def group_entries_by_date(self) -> pandas.DataFrame:
-        data_grouped_by_date = self.data.groupby("start_date", as_index=False)
-        return data_grouped_by_date
-
-    def sum_work_hours_up(self) -> pandas.DataFrame:
-        data_with_sum_of_work_hours = self.data \
-            .agg(
-                    work_hours=pandas.NamedAgg(column="work_hours", aggfunc="sum"),
-                    individual_entries=pandas.NamedAgg(column="start_date", aggfunc="size")
-                )
-        return data_with_sum_of_work_hours
-
-    def rename_columns(self) -> pandas.DataFrame:
-        data_with_renamed_columns = self.data \
-            .rename(columns={
-                                "start_date": "Date", "work_hours": "Total work time",
-                                "individual_entries": "Individual entries"
-                            }
-                    )
-        return data_with_renamed_columns
-
-    def change_index(self) -> None:
-        self.name_index_column()
-        self.boost_index()
-
-    def name_index_column(self) -> None:
-        self.data.index.name = "ID"
-
-    def boost_index(self) -> None:
-        self.data.index += 1
-
-    def reorder_entries_from_the_latest_down_to_the_oldest_one(self) -> pandas.DataFrame:
-        reordered_data = self.data.iloc[::-1]
-        return reordered_data

--- a/src/handler/entry_handler/EntryHandler.py
+++ b/src/handler/entry_handler/EntryHandler.py
@@ -1,11 +1,11 @@
 import pandas
 
-from src.csv.CSVAttributes import CSVAttributes
 from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
+from src.handler.entry_handler.BaseEntryHandlerClass import BaseEntryHandlerClass
 from src.handler.entry_handler.GroupedEntryHandler import GroupedEntryHandler
 
 
-class EntryHandler(CSVAttributes):
+class EntryHandler(BaseEntryHandlerClass):
     def __init__(self):
         super(EntryHandler, self).__init__()
 
@@ -19,26 +19,26 @@ class EntryHandler(CSVAttributes):
         except KeyError:
             raise InvalidIDOfDateException
 
-        self.grouped_entry_handler.data = self.grouped_entry_handler.get_data()
-        self.grouped_entry_handler.data = self.grouped_entry_handler.group_entries_by_date()
+        self.data = self.get_data()
+        self.data = self.group_entries_by_date()
 
-        entries_of_date_at_index: pandas.DataFrame = self.grouped_entry_handler.data.get_group(date)
-        entries_of_date_at_index.reset_index()
-        entries_of_date_at_index.index += 1
+        self.data: pandas.DataFrame = self.data.get_group(date)
+        self.data.reset_index()
+        self.boost_index()
 
-        entries_of_date_at_index = entries_of_date_at_index \
+        self.data = self.data \
             .rename(columns={
                                 "start_date": "Start Date", "start_time": "Start Time",
                                 "stop_date": "Stop Date", "stop_time": "Stop Time",
                                 "work_hours": "Work hours", "message": "Message"
                             }
                     )
-        entries_of_date_at_index["Start"] = entries_of_date_at_index[["Start Date", "Start Time"]].apply(lambda x: " at ".join(x), axis=1)
-        entries_of_date_at_index["Stop"] = entries_of_date_at_index[["Stop Date", "Stop Time"]].apply(lambda x: " at ".join(x), axis=1)
+        self.data["Start"] = self.data[["Start Date", "Start Time"]].apply(lambda x: " at ".join(x), axis=1)
+        self.data["Stop"] = self.data[["Stop Date", "Stop Time"]].apply(lambda x: " at ".join(x), axis=1)
 
-        entries_of_date_at_index = entries_of_date_at_index.drop(columns=["Start Date", "Start Time", "Stop Date", "Stop Time"])
-        entries_of_date_at_index = entries_of_date_at_index[["Start", "Stop", "Work hours", "Message"]]
+        self.data = self.data.drop(columns=["Start Date", "Start Time", "Stop Date", "Stop Time"])
+        self.data = self.data[["Start", "Stop", "Work hours", "Message"]]
 
         pandas.set_option("display.max_colwidth", None)
 
-        return [date, entries_of_date_at_index]
+        return [date, self.data]

--- a/src/handler/entry_handler/EntryHandler.py
+++ b/src/handler/entry_handler/EntryHandler.py
@@ -9,36 +9,70 @@ class EntryHandler(BaseEntryHandlerClass):
     def __init__(self):
         super(EntryHandler, self).__init__()
 
-        self.data = None
+        self.entries = None
         self.grouped_entry_handler = GroupedEntryHandler()
 
     def get_entries_of_specific_date(self, id_of_date: int) -> list:
-        entries_grouped_by_date = self.grouped_entry_handler.get_entries_grouped_by_date()
         try:
-            date = entries_grouped_by_date.at[id_of_date, "Date"]
+            date = self.get_string_of_date_by_id(id_of_date)
         except KeyError:
             raise InvalidIDOfDateException
 
         self.data = self.get_data()
         self.data = self.group_entries_by_date()
 
-        self.data: pandas.DataFrame = self.data.get_group(date)
-        self.data.reset_index()
-        self.boost_index()
+        self.entries = self.data.get_group(date)
+        self.change_index()
 
-        self.data = self.data \
+        self.entries = self.rename_columns()
+        self.merge_date_and_time_columns()
+
+        self.remove_start_and_stop_date_and_start_and_stop_time_columns()
+        self.reorder_columns()
+
+        # Make pandas print a message over more than one line in the console
+        pandas.set_option("display.max_colwidth", None)
+
+        return [date, self.entries]
+
+    def rename_columns(self) -> pandas.DataFrame:
+        entries_with_renamed_columns = self.entries \
             .rename(columns={
                                 "start_date": "Start Date", "start_time": "Start Time",
                                 "stop_date": "Stop Date", "stop_time": "Stop Time",
                                 "work_hours": "Work hours", "message": "Message"
                             }
                     )
-        self.data["Start"] = self.data[["Start Date", "Start Time"]].apply(lambda x: " at ".join(x), axis=1)
-        self.data["Stop"] = self.data[["Stop Date", "Stop Time"]].apply(lambda x: " at ".join(x), axis=1)
+        return entries_with_renamed_columns
 
-        self.data = self.data.drop(columns=["Start Date", "Start Time", "Stop Date", "Stop Time"])
-        self.data = self.data[["Start", "Stop", "Work hours", "Message"]]
+    def remove_start_and_stop_date_and_start_and_stop_time_columns(self) -> None:
+        self.entries = self.entries.drop(columns=["Start Date", "Start Time", "Stop Date", "Stop Time"])
 
-        pandas.set_option("display.max_colwidth", None)
+    def reorder_columns(self) -> None:
+        self.entries = self.entries[["Start", "Stop", "Work hours", "Message"]]
 
-        return [date, self.data]
+    def merge_date_and_time_columns(self) -> None:
+        self.merge_start_date_and_start_time()
+        self.merge_stop_date_and_stop_time()
+
+    def merge_start_date_and_start_time(self) -> None:
+        self.entries["Start"] = self.entries[["Start Date", "Start Time"]].apply(lambda x: " at ".join(x), axis=1)
+
+    def merge_stop_date_and_stop_time(self) -> None:
+        self.entries["Stop"] = self.entries[["Stop Date", "Stop Time"]].apply(lambda x: " at ".join(x), axis=1)
+
+    def get_string_of_date_by_id(self, id_of_date: int) -> str:
+        entries_grouped_by_date = self.grouped_entry_handler.get_entries_grouped_by_date()
+
+        date = entries_grouped_by_date.at[id_of_date, "Date"]
+        return date
+
+    def change_index(self) -> None:
+        self.reset_index()
+        self.boost_index()
+
+    def reset_index(self) -> None:
+        self.entries.reset_index()
+
+    def boost_index(self) -> None:
+        self.entries.index += 1

--- a/src/handler/entry_handler/EntryHandler.py
+++ b/src/handler/entry_handler/EntryHandler.py
@@ -24,42 +24,17 @@ class EntryHandler(BaseEntryHandlerClass):
         self.entries = self.data.get_group(date)
         self.change_index()
 
-        self.entries = self.rename_columns()
         self.merge_date_and_time_columns()
 
         self.remove_start_and_stop_date_and_start_and_stop_time_columns()
         self.reorder_columns()
 
+        self.entries = self.rename_columns()
+
         # Make pandas print a message over more than one line in the console
         pandas.set_option("display.max_colwidth", None)
 
         return [date, self.entries]
-
-    def rename_columns(self) -> pandas.DataFrame:
-        entries_with_renamed_columns = self.entries \
-            .rename(columns={
-                                "start_date": "Start Date", "start_time": "Start Time",
-                                "stop_date": "Stop Date", "stop_time": "Stop Time",
-                                "work_hours": "Work hours", "message": "Message"
-                            }
-                    )
-        return entries_with_renamed_columns
-
-    def remove_start_and_stop_date_and_start_and_stop_time_columns(self) -> None:
-        self.entries = self.entries.drop(columns=["Start Date", "Start Time", "Stop Date", "Stop Time"])
-
-    def reorder_columns(self) -> None:
-        self.entries = self.entries[["Start", "Stop", "Work hours", "Message"]]
-
-    def merge_date_and_time_columns(self) -> None:
-        self.merge_start_date_and_start_time()
-        self.merge_stop_date_and_stop_time()
-
-    def merge_start_date_and_start_time(self) -> None:
-        self.entries["Start"] = self.entries[["Start Date", "Start Time"]].apply(lambda x: " at ".join(x), axis=1)
-
-    def merge_stop_date_and_stop_time(self) -> None:
-        self.entries["Stop"] = self.entries[["Stop Date", "Stop Time"]].apply(lambda x: " at ".join(x), axis=1)
 
     def get_string_of_date_by_id(self, id_of_date: int) -> str:
         entries_grouped_by_date = self.grouped_entry_handler.get_entries_grouped_by_date()
@@ -76,3 +51,34 @@ class EntryHandler(BaseEntryHandlerClass):
 
     def boost_index(self) -> None:
         self.entries.index += 1
+
+    def rename_columns(self) -> pandas.DataFrame:
+        entries_with_renamed_columns = self.entries \
+            .rename(columns={
+                                "start": "Start",
+                                "stop": "Stop",
+                                "work_hours": "Work hours", "message": "Message"
+                            }
+                    )
+        return entries_with_renamed_columns
+
+    def merge_date_and_time_columns(self) -> None:
+        # Below is just work around for pandas' error: pandas.core.common.SettingWithCopyError
+        pandas.set_option("mode.chained_assignment", None)
+
+        self.merge_start_date_and_start_time()
+        self.merge_stop_date_and_stop_time()
+
+        pandas.set_option("mode.chained_assignment", "warn")
+
+    def merge_start_date_and_start_time(self) -> None:
+        self.entries.loc[:, "start"] = self.entries["start_date"] + " at " + self.entries["start_time"]
+
+    def merge_stop_date_and_stop_time(self) -> None:
+        self.entries.loc[:, "stop"] = self.entries["stop_date"] + " at " + self.entries["stop_time"]
+
+    def remove_start_and_stop_date_and_start_and_stop_time_columns(self) -> None:
+        self.entries = self.entries.drop(columns=["start_date", "start_time", "stop_date", "stop_time"])
+
+    def reorder_columns(self) -> None:
+        self.entries = self.entries[["start", "stop", "work_hours", "message"]]

--- a/src/handler/entry_handler/EntryHandler.py
+++ b/src/handler/entry_handler/EntryHandler.py
@@ -1,6 +1,7 @@
 import pandas
 
 from src.csv.CSVAttributes import CSVAttributes
+from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
 
 
 class EntryHandler(CSVAttributes):
@@ -11,7 +12,10 @@ class EntryHandler(CSVAttributes):
 
     def get_entries_of_specific_date(self, id_of_date: int) -> list:
         entries_grouped_by_date = self.get_entries_grouped_by_date()
-        date = entries_grouped_by_date.at[id_of_date, "Date"]
+        try:
+            date = entries_grouped_by_date.at[id_of_date, "Date"]
+        except KeyError:
+            raise InvalidIDOfDateException
 
         self.data = self.get_data()
         self.data = self.group_entries_by_date()

--- a/src/handler/entry_handler/GroupedEntryHandler.py
+++ b/src/handler/entry_handler/GroupedEntryHandler.py
@@ -1,0 +1,98 @@
+import pandas
+
+from src.csv.CSVAttributes import CSVAttributes
+from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
+
+
+class GroupedEntryHandler(CSVAttributes):
+    def __init__(self):
+        super(GroupedEntryHandler, self).__init__()
+
+        self.data = None
+
+    def get_entries_of_specific_date(self, id_of_date: int) -> list:
+        entries_grouped_by_date = self.get_entries_grouped_by_date()
+        try:
+            date = entries_grouped_by_date.at[id_of_date, "Date"]
+        except KeyError:
+            raise InvalidIDOfDateException
+
+        self.data = self.get_data()
+        self.data = self.group_entries_by_date()
+
+        entries_of_date_at_index: pandas.DataFrame = self.data.get_group(date)
+        entries_of_date_at_index.reset_index()
+        entries_of_date_at_index.index += 1
+
+        entries_of_date_at_index = entries_of_date_at_index \
+            .rename(columns={
+                                "start_date": "Start Date", "start_time": "Start Time",
+                                "stop_date": "Stop Date", "stop_time": "Stop Time",
+                                "work_hours": "Work hours", "message": "Message"
+                            }
+                    )
+        entries_of_date_at_index["Start"] = entries_of_date_at_index[["Start Date", "Start Time"]].apply(lambda x: " at ".join(x), axis=1)
+        entries_of_date_at_index["Stop"] = entries_of_date_at_index[["Stop Date", "Stop Time"]].apply(lambda x: " at ".join(x), axis=1)
+
+        entries_of_date_at_index = entries_of_date_at_index.drop(columns=["Start Date", "Start Time", "Stop Date", "Stop Time"])
+        entries_of_date_at_index = entries_of_date_at_index[["Start", "Stop", "Work hours", "Message"]]
+
+        pandas.set_option("display.max_colwidth", None)
+
+        return [date, entries_of_date_at_index]
+
+    def get_entries_grouped_by_date(self) -> pandas.DataFrame:
+        self.data = self.get_data()
+
+        self.data = self.group_entries_by_date()
+        self.data = self.sum_work_hours_up()
+        self.data = self.rename_columns()
+
+        self.change_index()
+
+        self.data = self.reorder_entries_from_the_latest_down_to_the_oldest_one()
+
+        return self.data
+
+    def get_data(self) -> pandas.DataFrame:
+        data = pandas.read_csv(self.tracker_file, header=0)
+
+        # Change this column to a time type for allowing summing up the total work hours later
+        data["work_hours"] = pandas.to_timedelta(data.work_hours)
+
+        return data.fillna("")
+
+    def group_entries_by_date(self) -> pandas.DataFrame:
+        data_grouped_by_date = self.data.groupby("start_date", as_index=False)
+        return data_grouped_by_date
+
+    def sum_work_hours_up(self) -> pandas.DataFrame:
+        data_with_sum_of_work_hours = self.data \
+            .agg(
+                    work_hours=pandas.NamedAgg(column="work_hours", aggfunc="sum"),
+                    individual_entries=pandas.NamedAgg(column="start_date", aggfunc="size")
+                )
+        return data_with_sum_of_work_hours
+
+    def rename_columns(self) -> pandas.DataFrame:
+        data_with_renamed_columns = self.data \
+            .rename(columns={
+                                "start_date": "Date", "work_hours": "Total work time",
+                                "individual_entries": "Individual entries"
+                            }
+                    )
+        return data_with_renamed_columns
+
+    def change_index(self) -> None:
+        self.name_index_column()
+        self.boost_index()
+
+    def name_index_column(self) -> None:
+        self.data.index.name = "ID"
+
+    def boost_index(self) -> None:
+        self.data.index += 1
+
+    def reorder_entries_from_the_latest_down_to_the_oldest_one(self) -> pandas.DataFrame:
+        reordered_data = self.data.iloc[::-1]
+        return reordered_data

--- a/src/handler/entry_handler/GroupedEntryHandler.py
+++ b/src/handler/entry_handler/GroupedEntryHandler.py
@@ -7,8 +7,6 @@ class GroupedEntryHandler(BaseEntryHandlerClass):
     def __init__(self):
         super(GroupedEntryHandler, self).__init__()
 
-        self.data = None
-
     def get_entries_grouped_by_date(self) -> pandas.DataFrame:
         self.data = self.get_data()
 
@@ -45,6 +43,9 @@ class GroupedEntryHandler(BaseEntryHandlerClass):
 
     def name_index_column(self) -> None:
         self.data.index.name = "ID"
+
+    def boost_index(self) -> None:
+        self.data.index += 1
 
     def reorder_entries_from_the_latest_down_to_the_oldest_one(self) -> pandas.DataFrame:
         reordered_data = self.data.iloc[::-1]

--- a/src/handler/entry_handler/GroupedEntryHandler.py
+++ b/src/handler/entry_handler/GroupedEntryHandler.py
@@ -1,9 +1,9 @@
 import pandas
 
-from src.csv.CSVAttributes import CSVAttributes
+from src.handler.entry_handler.BaseEntryHandlerClass import BaseEntryHandlerClass
 
 
-class GroupedEntryHandler(CSVAttributes):
+class GroupedEntryHandler(BaseEntryHandlerClass):
     def __init__(self):
         super(GroupedEntryHandler, self).__init__()
 
@@ -21,18 +21,6 @@ class GroupedEntryHandler(CSVAttributes):
         self.data = self.reorder_entries_from_the_latest_down_to_the_oldest_one()
 
         return self.data
-
-    def get_data(self) -> pandas.DataFrame:
-        data = pandas.read_csv(self.tracker_file, header=0)
-
-        # Change this column to a time type for allowing summing up the total work hours later
-        data["work_hours"] = pandas.to_timedelta(data.work_hours)
-
-        return data.fillna("")
-
-    def group_entries_by_date(self) -> pandas.DataFrame:
-        data_grouped_by_date = self.data.groupby("start_date", as_index=False)
-        return data_grouped_by_date
 
     def sum_work_hours_up(self) -> pandas.DataFrame:
         data_with_sum_of_work_hours = self.data \
@@ -57,9 +45,6 @@ class GroupedEntryHandler(CSVAttributes):
 
     def name_index_column(self) -> None:
         self.data.index.name = "ID"
-
-    def boost_index(self) -> None:
-        self.data.index += 1
 
     def reorder_entries_from_the_latest_down_to_the_oldest_one(self) -> pandas.DataFrame:
         reordered_data = self.data.iloc[::-1]

--- a/src/handler/entry_handler/GroupedEntryHandler.py
+++ b/src/handler/entry_handler/GroupedEntryHandler.py
@@ -1,7 +1,6 @@
 import pandas
 
 from src.csv.CSVAttributes import CSVAttributes
-from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
 
 
 class GroupedEntryHandler(CSVAttributes):
@@ -9,37 +8,6 @@ class GroupedEntryHandler(CSVAttributes):
         super(GroupedEntryHandler, self).__init__()
 
         self.data = None
-
-    def get_entries_of_specific_date(self, id_of_date: int) -> list:
-        entries_grouped_by_date = self.get_entries_grouped_by_date()
-        try:
-            date = entries_grouped_by_date.at[id_of_date, "Date"]
-        except KeyError:
-            raise InvalidIDOfDateException
-
-        self.data = self.get_data()
-        self.data = self.group_entries_by_date()
-
-        entries_of_date_at_index: pandas.DataFrame = self.data.get_group(date)
-        entries_of_date_at_index.reset_index()
-        entries_of_date_at_index.index += 1
-
-        entries_of_date_at_index = entries_of_date_at_index \
-            .rename(columns={
-                                "start_date": "Start Date", "start_time": "Start Time",
-                                "stop_date": "Stop Date", "stop_time": "Stop Time",
-                                "work_hours": "Work hours", "message": "Message"
-                            }
-                    )
-        entries_of_date_at_index["Start"] = entries_of_date_at_index[["Start Date", "Start Time"]].apply(lambda x: " at ".join(x), axis=1)
-        entries_of_date_at_index["Stop"] = entries_of_date_at_index[["Stop Date", "Stop Time"]].apply(lambda x: " at ".join(x), axis=1)
-
-        entries_of_date_at_index = entries_of_date_at_index.drop(columns=["Start Date", "Start Time", "Stop Date", "Stop Time"])
-        entries_of_date_at_index = entries_of_date_at_index[["Start", "Stop", "Work hours", "Message"]]
-
-        pandas.set_option("display.max_colwidth", None)
-
-        return [date, entries_of_date_at_index]
 
     def get_entries_grouped_by_date(self) -> pandas.DataFrame:
         self.data = self.get_data()

--- a/tests/test_click_commands/test_log/test_log.py
+++ b/tests/test_click_commands/test_log/test_log.py
@@ -20,25 +20,17 @@ class TestLog(CommandBaseTestingClass):
         self.clean_and_init_tracker_file()
         setup_test_values()
 
-        id_of_date = -1
+        self.check_for_not_matching_id_of_date(-1)
+        self.check_for_not_matching_id_of_date(0)
+        self.check_for_not_matching_id_of_date(100)
+
+    def check_for_not_matching_id_of_date(self, id_of_date: int) -> None:
         self.run_cli(["log", f"-i {id_of_date}"])
 
         self.assertIn(f"We couldn't find a date matching the ID {id_of_date}.", self.result.output)
         self.assertIn("EXIT", self.result.output)
 
-        id_of_date = 0
-        self.run_cli(["log", f"-i {id_of_date}"])
-
-        self.assertIn(f"We couldn't find a date matching the ID {id_of_date}.", self.result.output)
-        self.assertIn("EXIT", self.result.output)
-
-        id_of_date = 100
-        self.run_cli(["log", f"-i {id_of_date}"])
-
-        self.assertIn(f"We couldn't find a date matching the ID {id_of_date}.", self.result.output)
-        self.assertIn("EXIT", self.result.output)
-
-    def test_logging_without_any_entries_existing(self) -> None:
+    def test_logging_without_any_grouped_entries_existing(self) -> None:
         self.clean_and_init_tracker_file()
 
         self.run_cli(["log"])
@@ -46,7 +38,7 @@ class TestLog(CommandBaseTestingClass):
 
         self.assertIn("Nothing to see yet.", self.result.output)
 
-    def test_logging_with_one_entry(self) -> None:
+    def test_logging_with_one_grouped_entry(self) -> None:
         self.clean_and_init_tracker_file()
 
         self.run_cli(["start"])
@@ -55,20 +47,20 @@ class TestLog(CommandBaseTestingClass):
         total_dates = 1
         self.check_for_log_message(total_dates)
 
-    def test_logging_with_multiple_entries(self) -> None:
-        self.clean_and_init_tracker_file()
-
-        setup_test_values()
-
-        total_dates = 2
-        self.check_for_log_message(total_dates)
-
     def check_for_log_message(self, total_dates: int) -> None:
         self.run_cli(["log"])
         self.assertEqual(self.result.exit_code, 0)
 
         self.assertIn("Showing all entries", self.result.output)
         self.assertIn(f"({total_dates} in total)", self.result.output)
+
+    def test_logging_with_multiple_grouped_entries(self) -> None:
+        self.clean_and_init_tracker_file()
+
+        setup_test_values()
+
+        total_dates = 2
+        self.check_for_log_message(total_dates)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_click_commands/test_log/test_log.py
+++ b/tests/test_click_commands/test_log/test_log.py
@@ -8,6 +8,36 @@ class TestLog(CommandBaseTestingClass):
     def setUp(self) -> None:
         super(TestLog, self).setUp()
 
+    def test_logging_a_specific_entry(self) -> None:
+        self.clean_and_init_tracker_file()
+        setup_test_values()
+
+        self.run_cli(["log", "-i 1"])
+
+        self.assertIn("Showing all entries of", self.result.output)
+
+    def test_logging_a_sepcific_entry_with_unknown_id(self) -> None:
+        self.clean_and_init_tracker_file()
+        setup_test_values()
+
+        id_of_date = -1
+        self.run_cli(["log", f"-i {id_of_date}"])
+
+        self.assertIn(f"We couldn't find a date matching the ID {id_of_date}.", self.result.output)
+        self.assertIn("EXIT", self.result.output)
+
+        id_of_date = 0
+        self.run_cli(["log", f"-i {id_of_date}"])
+
+        self.assertIn(f"We couldn't find a date matching the ID {id_of_date}.", self.result.output)
+        self.assertIn("EXIT", self.result.output)
+
+        id_of_date = 100
+        self.run_cli(["log", f"-i {id_of_date}"])
+
+        self.assertIn(f"We couldn't find a date matching the ID {id_of_date}.", self.result.output)
+        self.assertIn("EXIT", self.result.output)
+
     def test_logging_without_any_entries_existing(self) -> None:
         self.clean_and_init_tracker_file()
 

--- a/tests/test_handler/test_entry_handler/test_base_entry_handler_class.py
+++ b/tests/test_handler/test_entry_handler/test_base_entry_handler_class.py
@@ -1,0 +1,56 @@
+import unittest
+
+import pandas
+
+from src.setup_test_values import setup_test_values
+from src.csv.CSVAttributes import CSVAttributes
+from src.handler.entry_handler.BaseEntryHandlerClass import BaseEntryHandlerClass
+
+from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
+
+
+class TestBaseEntryHandlerClass(CSVBaseTestingClass):
+    def setUp(self) -> None:
+        super(TestBaseEntryHandlerClass, self).setUp()
+
+        self.data = None
+        self.csv_attributes = CSVAttributes()
+        self.base_entry_handler = BaseEntryHandlerClass()
+
+    def test_getting_empty_data(self) -> None:
+        self.clean_and_init_tracker_file()
+        self.data = self.base_entry_handler.get_data()
+        self.assertEqual(list(self.data.columns), self.csv_attributes.column_names)
+
+    def test_getting_filled_data(self) -> None:
+        self.clean_and_init_tracker_file()
+        setup_test_values()
+
+        self.data = self.base_entry_handler.get_data()
+
+        self.assertEqual(list(self.data.columns), self.csv_attributes.column_names)
+        self.assertTrue(len(self.data) > 0)
+
+        self.assertTrue(self.data["work_hours"].dtypes == "timedelta64[ns]")
+
+    def test_grouping_entries_by_date_with_empty_data(self) -> None:
+        self.clean_and_init_tracker_file()
+
+        self.base_entry_handler.data = self.base_entry_handler.get_data()
+        entries_grouped_by_date = self.base_entry_handler.group_entries_by_date()
+
+        self.assertEqual(len(entries_grouped_by_date), 0)
+
+    def test_grouping_entries_by_date_with_filled_data(self) -> None:
+        self.clean_and_init_tracker_file()
+        setup_test_values()
+
+        self.base_entry_handler.data = self.base_entry_handler.get_data()
+        entries_grouped_by_date = self.base_entry_handler.group_entries_by_date()
+
+        self.assertNotEqual(type(entries_grouped_by_date), pandas.DataFrame)
+        self.assertNotEqual(len(entries_grouped_by_date), 0)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_handler/test_entry_handler/test_entry_handler.py
+++ b/tests/test_handler/test_entry_handler/test_entry_handler.py
@@ -1,7 +1,11 @@
 import unittest
 
+import pandas
+
+from src.setup_test_values import setup_test_values
 from src.handler.entry_handler.EntryHandler import EntryHandler
 from src.handler.timer_handler.TimerHandler import TimerHandler
+from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
 
 from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
 
@@ -13,6 +17,25 @@ class TestEntryHandler(CSVBaseTestingClass):
         self.timer_handler = TimerHandler()
 
         self.column_names = ["Date", "Total work time", "Individual entries"]
+
+    def test_logging_entries_of_specific_date(self) -> None:
+        self.clean_and_init_tracker_file()
+        setup_test_values()
+
+        entries = self.entry_handler.get_entries_of_specific_date(1)
+
+        self.assertEqual(type(entries[0]), str)
+        self.assertEqual(type(entries[1]), pandas.DataFrame)
+
+        self.assertIn(entries[0], entries[1].at[1, "Start"])
+
+    def test_logging_entries_of_soecific_date_with_unknown_id(self) -> None:
+        self.clean_and_init_tracker_file()
+        setup_test_values()
+
+        self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, 0)
+        self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, 100)
+        self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, -1)
 
     def test_logging_without_any_entries(self) -> None:
         self.clean_and_init_tracker_file()

--- a/tests/test_handler/test_entry_handler/test_entry_handler.py
+++ b/tests/test_handler/test_entry_handler/test_entry_handler.py
@@ -3,6 +3,7 @@ import unittest
 import pandas
 
 from src.setup_test_values import setup_test_values
+from src.handler.entry_handler.GroupedEntryHandler import GroupedEntryHandler
 from src.handler.entry_handler.EntryHandler import EntryHandler
 from src.handler.timer_handler.TimerHandler import TimerHandler
 from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
@@ -13,6 +14,7 @@ from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
 class TestEntryHandler(CSVBaseTestingClass):
     def setUp(self) -> None:
         super(TestEntryHandler, self).setUp()
+        self.grouped_entry_handler = GroupedEntryHandler()
         self.entry_handler = EntryHandler()
         self.timer_handler = TimerHandler()
 
@@ -41,7 +43,7 @@ class TestEntryHandler(CSVBaseTestingClass):
     def check_for_invalid_id_of_date_exception(self, id_of_date: int) -> None:
         self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, id_of_date)
 
-    def test_logging_entries_of_soecific_date_with_unknown_id(self) -> None:
+    def test_logging_entries_of_specific_date_with_unknown_id(self) -> None:
         self.clean_and_init_tracker_file()
         setup_test_values()
 
@@ -54,7 +56,7 @@ class TestEntryHandler(CSVBaseTestingClass):
         self.assertEqual(self.get_length_of_grouped_entries(), 0)
 
     def get_length_of_grouped_entries(self) -> int:
-        return len(self.entry_handler.get_entries_grouped_by_date())
+        return len(self.grouped_entry_handler.get_entries_grouped_by_date())
 
     def test_logging_with_more_grouped_entries(self) -> None:
         self.clean_and_init_tracker_file()
@@ -81,10 +83,10 @@ class TestEntryHandler(CSVBaseTestingClass):
         self.clean_and_init_tracker_file()
         self.add_new_entry()
 
-        column_names = list(self.entry_handler.get_entries_grouped_by_date().columns)
+        column_names = list(self.grouped_entry_handler.get_entries_grouped_by_date().columns)
         self.assertEqual(column_names, self.column_names)
 
-        index_name = self.entry_handler.get_entries_grouped_by_date().index.name
+        index_name = self.grouped_entry_handler.get_entries_grouped_by_date().index.name
         self.assertEqual(index_name, "ID")
 
 

--- a/tests/test_handler/test_entry_handler/test_entry_handler.py
+++ b/tests/test_handler/test_entry_handler/test_entry_handler.py
@@ -14,11 +14,11 @@ from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
 class TestEntryHandler(CSVBaseTestingClass):
     def setUp(self) -> None:
         super(TestEntryHandler, self).setUp()
-        self.grouped_entry_handler = GroupedEntryHandler()
+        # self.grouped_entry_handler = GroupedEntryHandler()
         self.entry_handler = EntryHandler()
-        self.timer_handler = TimerHandler()
+        # self.timer_handler = TimerHandler()
 
-        self.column_names = ["Date", "Total work time", "Individual entries"]
+        # self.column_names = ["Date", "Total work time", "Individual entries"]
 
     def test_logging_entries_of_specific_date(self) -> None:
         self.clean_and_init_tracker_file()
@@ -51,43 +51,43 @@ class TestEntryHandler(CSVBaseTestingClass):
         self.check_for_invalid_id_of_date_exception(-1)
         self.check_for_invalid_id_of_date_exception(100)
 
-    def test_logging_without_any_grouped_entries(self) -> None:
-        self.clean_and_init_tracker_file()
-        self.assertEqual(self.get_length_of_grouped_entries(), 0)
-
-    def get_length_of_grouped_entries(self) -> int:
-        return len(self.grouped_entry_handler.get_entries_grouped_by_date())
-
-    def test_logging_with_more_grouped_entries(self) -> None:
-        self.clean_and_init_tracker_file()
-
-        self.add_new_entry()
-        self.assertEqual(self.get_length_of_grouped_entries(), 1)
-
-        self.timer_handler.start_timer()
-        self.timer_handler.stop_timer("")
-
-        # Entries are grouped by date, so adding two or more entries at the same day won't increase the length
-        self.add_new_entry()
-        self.assertEqual(self.get_length_of_grouped_entries(), 1)
-
-        self.add_new_entry()
-        self.add_new_entry()
-        self.assertEqual(self.get_length_of_grouped_entries(), 1)
-
-    def add_new_entry(self):
-        self.timer_handler.start_timer()
-        self.timer_handler.stop_timer("")
-
-    def test_column_names_of_grouped_entries(self):
-        self.clean_and_init_tracker_file()
-        self.add_new_entry()
-
-        column_names = list(self.grouped_entry_handler.get_entries_grouped_by_date().columns)
-        self.assertEqual(column_names, self.column_names)
-
-        index_name = self.grouped_entry_handler.get_entries_grouped_by_date().index.name
-        self.assertEqual(index_name, "ID")
+    # def test_logging_without_any_grouped_entries(self) -> None:
+    #     self.clean_and_init_tracker_file()
+    #     self.assertEqual(self.get_length_of_grouped_entries(), 0)
+    #
+    # def get_length_of_grouped_entries(self) -> int:
+    #     return len(self.grouped_entry_handler.get_entries_grouped_by_date())
+    #
+    # def test_logging_with_more_grouped_entries(self) -> None:
+    #     self.clean_and_init_tracker_file()
+    #
+    #     self.add_new_entry()
+    #     self.assertEqual(self.get_length_of_grouped_entries(), 1)
+    #
+    #     self.timer_handler.start_timer()
+    #     self.timer_handler.stop_timer("")
+    #
+    #     # Entries are grouped by date, so adding two or more entries at the same day won't increase the length
+    #     self.add_new_entry()
+    #     self.assertEqual(self.get_length_of_grouped_entries(), 1)
+    #
+    #     self.add_new_entry()
+    #     self.add_new_entry()
+    #     self.assertEqual(self.get_length_of_grouped_entries(), 1)
+    #
+    # def add_new_entry(self):
+    #     self.timer_handler.start_timer()
+    #     self.timer_handler.stop_timer("")
+    #
+    # def test_column_names_of_grouped_entries(self):
+    #     self.clean_and_init_tracker_file()
+    #     self.add_new_entry()
+    #
+    #     column_names = list(self.grouped_entry_handler.get_entries_grouped_by_date().columns)
+    #     self.assertEqual(column_names, self.column_names)
+    #
+    #     index_name = self.grouped_entry_handler.get_entries_grouped_by_date().index.name
+    #     self.assertEqual(index_name, "ID")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_handler/test_entry_handler/test_entry_handler.py
+++ b/tests/test_handler/test_entry_handler/test_entry_handler.py
@@ -23,42 +23,61 @@ class TestEntryHandler(CSVBaseTestingClass):
         setup_test_values()
 
         entries = self.entry_handler.get_entries_of_specific_date(1)
+        date = entries[0]
+        entries_of_date = entries[1]
 
-        self.assertEqual(type(entries[0]), str)
-        self.assertEqual(type(entries[1]), pandas.DataFrame)
+        self.assertEqual(type(date), str)
+        self.assertEqual(type(entries_of_date), pandas.DataFrame)
 
-        self.assertIn(entries[0], entries[1].at[1, "Start"])
+        self.assertIn(date, entries_of_date.at[1, "Start"])
+
+    def test_logging_entries_of_specific_date_without_any_entries(self) -> None:
+        self.clean_and_init_tracker_file()
+
+        self.check_for_invalid_id_of_date_exception(0)
+        self.check_for_invalid_id_of_date_exception(1)
+        self.check_for_invalid_id_of_date_exception(2)
+
+    def check_for_invalid_id_of_date_exception(self, id_of_date: int) -> None:
+        self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, id_of_date)
 
     def test_logging_entries_of_soecific_date_with_unknown_id(self) -> None:
         self.clean_and_init_tracker_file()
         setup_test_values()
 
-        self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, 0)
-        self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, 100)
-        self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, -1)
+        self.check_for_invalid_id_of_date_exception(0)
+        self.check_for_invalid_id_of_date_exception(-1)
+        self.check_for_invalid_id_of_date_exception(100)
 
-    def test_logging_without_any_entries(self) -> None:
+    def test_logging_without_any_grouped_entries(self) -> None:
         self.clean_and_init_tracker_file()
-        self.assertEqual(self.get_length_of_entries(), 0)
+        self.assertEqual(self.get_length_of_grouped_entries(), 0)
 
-    def test_logging_with_more_entries(self) -> None:
+    def get_length_of_grouped_entries(self) -> int:
+        return len(self.entry_handler.get_entries_grouped_by_date())
+
+    def test_logging_with_more_grouped_entries(self) -> None:
         self.clean_and_init_tracker_file()
 
         self.add_new_entry()
-        self.assertEqual(self.get_length_of_entries(), 1)
+        self.assertEqual(self.get_length_of_grouped_entries(), 1)
 
         self.timer_handler.start_timer()
         self.timer_handler.stop_timer("")
 
         # Entries are grouped by date, so adding two or more entries at the same day won't increase the length
         self.add_new_entry()
-        self.assertEqual(self.get_length_of_entries(), 1)
+        self.assertEqual(self.get_length_of_grouped_entries(), 1)
 
         self.add_new_entry()
         self.add_new_entry()
-        self.assertEqual(self.get_length_of_entries(), 1)
+        self.assertEqual(self.get_length_of_grouped_entries(), 1)
 
-    def test_column_names(self):
+    def add_new_entry(self):
+        self.timer_handler.start_timer()
+        self.timer_handler.stop_timer("")
+
+    def test_column_names_of_grouped_entries(self):
         self.clean_and_init_tracker_file()
         self.add_new_entry()
 
@@ -67,13 +86,6 @@ class TestEntryHandler(CSVBaseTestingClass):
 
         index_name = self.entry_handler.get_entries_grouped_by_date().index.name
         self.assertEqual(index_name, "ID")
-
-    def get_length_of_entries(self) -> int:
-        return len(self.entry_handler.get_entries_grouped_by_date())
-
-    def add_new_entry(self):
-        self.timer_handler.start_timer()
-        self.timer_handler.stop_timer("")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_handler/test_entry_handler/test_entry_handler.py
+++ b/tests/test_handler/test_entry_handler/test_entry_handler.py
@@ -31,7 +31,7 @@ class TestEntryHandler(CSVBaseTestingClass):
 
         self.assertIn(date, entries_of_date.at[1, "Start"])
 
-    def test_logging_entries_of_specific_date_without_any_entries(self) -> None:
+    def test_logging_entries_of_specific_date_without_any_entries_existing(self) -> None:
         self.clean_and_init_tracker_file()
 
         self.check_for_invalid_id_of_date_exception(0)

--- a/tests/test_handler/test_entry_handler/test_entry_handler.py
+++ b/tests/test_handler/test_entry_handler/test_entry_handler.py
@@ -3,9 +3,8 @@ import unittest
 import pandas
 
 from src.setup_test_values import setup_test_values
-from src.handler.entry_handler.GroupedEntryHandler import GroupedEntryHandler
+
 from src.handler.entry_handler.EntryHandler import EntryHandler
-from src.handler.timer_handler.TimerHandler import TimerHandler
 from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
 
 from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
@@ -14,11 +13,8 @@ from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
 class TestEntryHandler(CSVBaseTestingClass):
     def setUp(self) -> None:
         super(TestEntryHandler, self).setUp()
-        # self.grouped_entry_handler = GroupedEntryHandler()
-        self.entry_handler = EntryHandler()
-        # self.timer_handler = TimerHandler()
 
-        # self.column_names = ["Date", "Total work time", "Individual entries"]
+        self.entry_handler = EntryHandler()
 
     def test_logging_entries_of_specific_date(self) -> None:
         self.clean_and_init_tracker_file()
@@ -50,44 +46,6 @@ class TestEntryHandler(CSVBaseTestingClass):
         self.check_for_invalid_id_of_date_exception(0)
         self.check_for_invalid_id_of_date_exception(-1)
         self.check_for_invalid_id_of_date_exception(100)
-
-    # def test_logging_without_any_grouped_entries(self) -> None:
-    #     self.clean_and_init_tracker_file()
-    #     self.assertEqual(self.get_length_of_grouped_entries(), 0)
-    #
-    # def get_length_of_grouped_entries(self) -> int:
-    #     return len(self.grouped_entry_handler.get_entries_grouped_by_date())
-    #
-    # def test_logging_with_more_grouped_entries(self) -> None:
-    #     self.clean_and_init_tracker_file()
-    #
-    #     self.add_new_entry()
-    #     self.assertEqual(self.get_length_of_grouped_entries(), 1)
-    #
-    #     self.timer_handler.start_timer()
-    #     self.timer_handler.stop_timer("")
-    #
-    #     # Entries are grouped by date, so adding two or more entries at the same day won't increase the length
-    #     self.add_new_entry()
-    #     self.assertEqual(self.get_length_of_grouped_entries(), 1)
-    #
-    #     self.add_new_entry()
-    #     self.add_new_entry()
-    #     self.assertEqual(self.get_length_of_grouped_entries(), 1)
-    #
-    # def add_new_entry(self):
-    #     self.timer_handler.start_timer()
-    #     self.timer_handler.stop_timer("")
-    #
-    # def test_column_names_of_grouped_entries(self):
-    #     self.clean_and_init_tracker_file()
-    #     self.add_new_entry()
-    #
-    #     column_names = list(self.grouped_entry_handler.get_entries_grouped_by_date().columns)
-    #     self.assertEqual(column_names, self.column_names)
-    #
-    #     index_name = self.grouped_entry_handler.get_entries_grouped_by_date().index.name
-    #     self.assertEqual(index_name, "ID")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_handler/test_entry_handler/test_grouped_entry_handler.py
+++ b/tests/test_handler/test_entry_handler/test_grouped_entry_handler.py
@@ -1,0 +1,94 @@
+import unittest
+
+import pandas
+
+from src.setup_test_values import setup_test_values
+from src.handler.entry_handler.GroupedEntryHandler import GroupedEntryHandler
+from src.handler.entry_handler.EntryHandler import EntryHandler
+from src.handler.timer_handler.TimerHandler import TimerHandler
+from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
+
+from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
+
+
+class TestGroupedEntryHandler(CSVBaseTestingClass):
+    def setUp(self) -> None:
+        super(TestGroupedEntryHandler, self).setUp()
+        self.grouped_entry_handler = GroupedEntryHandler()
+        # self.entry_handler = EntryHandler()
+        self.timer_handler = TimerHandler()
+
+        self.column_names = ["Date", "Total work time", "Individual entries"]
+
+    # def test_logging_entries_of_specific_date(self) -> None:
+    #     self.clean_and_init_tracker_file()
+    #     setup_test_values()
+    #
+    #     entries = self.entry_handler.get_entries_of_specific_date(1)
+    #     date = entries[0]
+    #     entries_of_date = entries[1]
+    #
+    #     self.assertEqual(type(date), str)
+    #     self.assertEqual(type(entries_of_date), pandas.DataFrame)
+    #
+    #     self.assertIn(date, entries_of_date.at[1, "Start"])
+    #
+    # def test_logging_entries_of_specific_date_without_any_entries_existing(self) -> None:
+    #     self.clean_and_init_tracker_file()
+    #
+    #     self.check_for_invalid_id_of_date_exception(0)
+    #     self.check_for_invalid_id_of_date_exception(1)
+    #     self.check_for_invalid_id_of_date_exception(2)
+    #
+    # def check_for_invalid_id_of_date_exception(self, id_of_date: int) -> None:
+    #     self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, id_of_date)
+    #
+    # def test_logging_entries_of_specific_date_with_unknown_id(self) -> None:
+    #     self.clean_and_init_tracker_file()
+    #     setup_test_values()
+    #
+    #     self.check_for_invalid_id_of_date_exception(0)
+    #     self.check_for_invalid_id_of_date_exception(-1)
+    #     self.check_for_invalid_id_of_date_exception(100)
+
+    def test_logging_without_any_grouped_entries(self) -> None:
+        self.clean_and_init_tracker_file()
+        self.assertEqual(self.get_length_of_grouped_entries(), 0)
+
+    def get_length_of_grouped_entries(self) -> int:
+        return len(self.grouped_entry_handler.get_entries_grouped_by_date())
+
+    def test_logging_with_more_grouped_entries(self) -> None:
+        self.clean_and_init_tracker_file()
+
+        self.add_new_entry()
+        self.assertEqual(self.get_length_of_grouped_entries(), 1)
+
+        self.timer_handler.start_timer()
+        self.timer_handler.stop_timer("")
+
+        # Entries are grouped by date, so adding two or more entries at the same day won't increase the length
+        self.add_new_entry()
+        self.assertEqual(self.get_length_of_grouped_entries(), 1)
+
+        self.add_new_entry()
+        self.add_new_entry()
+        self.assertEqual(self.get_length_of_grouped_entries(), 1)
+
+    def add_new_entry(self):
+        self.timer_handler.start_timer()
+        self.timer_handler.stop_timer("")
+
+    def test_column_names_of_grouped_entries(self):
+        self.clean_and_init_tracker_file()
+        self.add_new_entry()
+
+        column_names = list(self.grouped_entry_handler.get_entries_grouped_by_date().columns)
+        self.assertEqual(column_names, self.column_names)
+
+        index_name = self.grouped_entry_handler.get_entries_grouped_by_date().index.name
+        self.assertEqual(index_name, "ID")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_handler/test_entry_handler/test_grouped_entry_handler.py
+++ b/tests/test_handler/test_entry_handler/test_grouped_entry_handler.py
@@ -1,12 +1,7 @@
 import unittest
 
-import pandas
-
-from src.setup_test_values import setup_test_values
 from src.handler.entry_handler.GroupedEntryHandler import GroupedEntryHandler
-from src.handler.entry_handler.EntryHandler import EntryHandler
 from src.handler.timer_handler.TimerHandler import TimerHandler
-from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
 
 from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
 
@@ -15,41 +10,9 @@ class TestGroupedEntryHandler(CSVBaseTestingClass):
     def setUp(self) -> None:
         super(TestGroupedEntryHandler, self).setUp()
         self.grouped_entry_handler = GroupedEntryHandler()
-        # self.entry_handler = EntryHandler()
         self.timer_handler = TimerHandler()
 
         self.column_names = ["Date", "Total work time", "Individual entries"]
-
-    # def test_logging_entries_of_specific_date(self) -> None:
-    #     self.clean_and_init_tracker_file()
-    #     setup_test_values()
-    #
-    #     entries = self.entry_handler.get_entries_of_specific_date(1)
-    #     date = entries[0]
-    #     entries_of_date = entries[1]
-    #
-    #     self.assertEqual(type(date), str)
-    #     self.assertEqual(type(entries_of_date), pandas.DataFrame)
-    #
-    #     self.assertIn(date, entries_of_date.at[1, "Start"])
-    #
-    # def test_logging_entries_of_specific_date_without_any_entries_existing(self) -> None:
-    #     self.clean_and_init_tracker_file()
-    #
-    #     self.check_for_invalid_id_of_date_exception(0)
-    #     self.check_for_invalid_id_of_date_exception(1)
-    #     self.check_for_invalid_id_of_date_exception(2)
-    #
-    # def check_for_invalid_id_of_date_exception(self, id_of_date: int) -> None:
-    #     self.assertRaises(InvalidIDOfDateException, self.entry_handler.get_entries_of_specific_date, id_of_date)
-    #
-    # def test_logging_entries_of_specific_date_with_unknown_id(self) -> None:
-    #     self.clean_and_init_tracker_file()
-    #     setup_test_values()
-    #
-    #     self.check_for_invalid_id_of_date_exception(0)
-    #     self.check_for_invalid_id_of_date_exception(-1)
-    #     self.check_for_invalid_id_of_date_exception(100)
 
     def test_logging_without_any_grouped_entries(self) -> None:
         self.clean_and_init_tracker_file()


### PR DESCRIPTION
Extend the functionality of tracker log by allowing to view a specific day. Use the ID of a day to view it by typing `tracker log -i <ID>`.

- [X] Test verifying change added.

Closes #5 

