### PR TITLE
Refactor setting up test values for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test: clean
 	@python3 -m unittest discover
 setup: clean
 	@echo "Setting up test values"
-	@python3 -m src.setup_test_values -e ${entries}
+	@python3 -m src.setup -e ${entries}
 coverage: clean
 	@python3 -m coverage run --omit=/usr/*,*__init__.py -m unittest discover
 	@python3 -m coverage report

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+entries ?= 4
+
 all:
 	@echo "Running Tracker"
 	@python3 -m src.main
@@ -12,7 +14,7 @@ test: clean
 	@python3 -m unittest discover
 setup: clean
 	@echo "Setting up test values"
-	@python3 -m src.setup_test_values
+	@python3 -m src.setup_test_values -e ${entries}
 coverage: clean
 	@python3 -m coverage run --omit=/usr/*,*__init__.py -m unittest discover
 	@python3 -m coverage report

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,0 +1,57 @@
+import click
+import num2words
+
+from src.console_logger.console_logger import info, warn
+from src.setup_test_values.setup_test_values import SetupTestValues
+
+
+class SetupTestValuesForConsole:
+    def __init__(self):
+        self.set_upper = SetupTestValues()
+
+        self.number_of_entries = 0
+        self.number_of_entries_as_word = ""
+
+    def setup(self, number_of_entries: int):
+        self.number_of_entries = number_of_entries
+        self.try_to_set_new_number_of_entries()
+
+        self.set_upper.setup()
+
+        self.convert_number_of_entries_into_word()
+        self.print_success_message()
+
+    def try_to_set_new_number_of_entries(self) -> None:
+        try:
+            self.set_upper.set_number_of_entries(self.number_of_entries)
+        except ValueError:
+            self.handle_invalid_number_of_entries()
+
+    def handle_invalid_number_of_entries(self) -> None:
+        warn(f"The number of entries cannot be negative (was {self.number_of_entries}). "
+             f"Please specify a value greater than or equal zero.\n"
+             "EXIT")
+        exit(-1)
+
+    def convert_number_of_entries_into_word(self):
+        self.number_of_entries_as_word = num2words.num2words(self.number_of_entries)
+
+    def print_success_message(self) -> None:
+        if self.number_of_entries == 1:
+            message_of_created_entries = "one entry"
+        else:
+            message_of_created_entries = f"{self.number_of_entries_as_word} entries"
+
+        info(f"\nSuccesfully setup {message_of_created_entries}.\n"
+             f"OK")
+
+
+@click.command()
+@click.option("-e", "--entries", "number_of_entries", help="Number of entries to create", type=int, default=4)
+def main(number_of_entries: int) -> None:
+    console_set_upper = SetupTestValuesForConsole()
+    console_set_upper.setup(number_of_entries)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/setup.py
+++ b/src/setup.py
@@ -7,40 +7,40 @@ from src.setup_test_values.setup_test_values import SetupTestValues
 
 class SetupTestValuesForConsole:
     def __init__(self):
-        self.set_upper = SetupTestValues()
+        self.__set_upper = SetupTestValues()
 
-        self.number_of_entries = 0
-        self.number_of_entries_as_word = ""
+        self.__number_of_entries = 0
+        self.__number_of_entries_as_word = ""
 
     def setup(self, number_of_entries: int):
-        self.number_of_entries = number_of_entries
-        self.try_to_set_new_number_of_entries()
+        self.__number_of_entries = number_of_entries
+        self.__try_to_set_new_number_of_entries()
 
-        self.set_upper.setup()
+        self.__set_upper.setup()
 
-        self.convert_number_of_entries_into_word()
-        self.print_success_message()
+        self.__convert_number_of_entries_into_word()
+        self.__print_success_message()
 
-    def try_to_set_new_number_of_entries(self) -> None:
+    def __try_to_set_new_number_of_entries(self) -> None:
         try:
-            self.set_upper.set_number_of_entries(self.number_of_entries)
+            self.__set_upper.set_number_of_entries(self.__number_of_entries)
         except ValueError:
-            self.handle_invalid_number_of_entries()
+            self.__handle_invalid_number_of_entries()
 
-    def handle_invalid_number_of_entries(self) -> None:
-        warn(f"The number of entries cannot be negative (was {self.number_of_entries}). "
+    def __handle_invalid_number_of_entries(self) -> None:
+        warn(f"The number of entries cannot be negative (was {self.__number_of_entries}). "
              f"Please specify a value greater than or equal zero.\n"
              "EXIT")
         exit(-1)
 
-    def convert_number_of_entries_into_word(self):
-        self.number_of_entries_as_word = num2words.num2words(self.number_of_entries)
+    def __convert_number_of_entries_into_word(self):
+        self.__number_of_entries_as_word = num2words.num2words(self.__number_of_entries)
 
-    def print_success_message(self) -> None:
-        if self.number_of_entries == 1:
+    def __print_success_message(self) -> None:
+        if self.__number_of_entries == 1:
             message_of_created_entries = "one entry"
         else:
-            message_of_created_entries = f"{self.number_of_entries_as_word} entries"
+            message_of_created_entries = f"{self.__number_of_entries_as_word} entries"
 
         info(f"\nSuccesfully setup {message_of_created_entries}.\n"
              f"OK")

--- a/src/setup_test_values/entry.py
+++ b/src/setup_test_values/entry.py
@@ -5,10 +5,12 @@ from datetime import datetime, time
 class Entry:
     def __init__(self) -> None:
         self.start_date = ""
-        self.start_time = None
-
         self.stop_date = ""
+
+        self.start_time = None
         self.stop_time = None
+        self.start_time_dict = {}
+        self.stop_time_dict = {}
 
         self.work_hours = ""
         self.message = ""
@@ -17,10 +19,6 @@ class Entry:
 
         self.month = "Jan"
         self.year = "2022"
-
-        self.hours = {}
-        self.minutes = {}
-        self.seconds = {}
 
     def build(self, message: str, number: int) -> str:
         self.number = number
@@ -41,8 +39,6 @@ class Entry:
         self.create_time()
 
     def create_date(self) -> None:
-        number = 0
-
         # Count the date in double steps, makes two entries per day
         if self.is_first_entry_of_day():
             # 1 -> 1 + 1 / 2 = 1
@@ -54,6 +50,8 @@ class Entry:
             # 4 -> 2
             # 6 -> 3
             number = self.number / 2
+        else:
+           number = 0
 
         date = int(number / 2)
 
@@ -67,23 +65,32 @@ class Entry:
         return self.number % 2 == 0
 
     def create_time(self) -> None:
-        # CREATE HOURS
+        self.create_time_dict()
+
+        self.start_time = time(**self.start_time_dict)
+        self.stop_time = time(**self.stop_time_dict)
+
+    def create_time_dict(self) -> None:
         hours = self.calculate_hours()
-        start_hour = hours["start"]
-        stop_hour = hours["stop"]
-
-        # CREATE MINUTES
         minutes = self.calculate_minutes()
-        start_minutes = minutes["start"]
-        stop_minutes = minutes["stop"]
-
-        # CREATE SECONDS
         seconds = self.calculate_seconds()
+
+        self.create_start_time_dict(hours, minutes, seconds)
+        self.create_stop_time_dict(hours, minutes, seconds)
+
+    def create_start_time_dict(self, hours: dict, minutes: dict, seconds: dict) -> None:
+        start_hour = hours["start"]
+        start_minutes = minutes["start"]
         start_seconds = seconds["start"]
+
+        self.start_time_dict = {"hour": start_hour, "minute": start_minutes, "second": start_seconds}
+
+    def create_stop_time_dict(self, hours: dict, minutes: dict, seconds: dict) -> None:
+        stop_hour = hours["stop"]
+        stop_minutes = minutes["stop"]
         stop_seconds = seconds["stop"]
 
-        self.start_time = time(start_hour, start_minutes, start_seconds)
-        self.stop_time = time(stop_hour, stop_minutes, stop_seconds)
+        self.stop_time_dict = {"hour": stop_hour, "minute": stop_minutes, "second": stop_seconds}
 
     def calculate_hours(self) -> dict:
         start_hour = random.randint(0, 11)

--- a/src/setup_test_values/entry.py
+++ b/src/setup_test_values/entry.py
@@ -13,7 +13,6 @@ class Entry:
         self.work_hours = ""
         self.message = ""
 
-        self.messages = []
         self.number = 0
 
         self.month = "Jan"
@@ -23,13 +22,12 @@ class Entry:
         self.minutes = {}
         self.seconds = {}
 
-    def build(self, messages: list, number: int) -> str:
+    def build(self, message: str, number: int) -> str:
         self.number = number
-        self.messages = messages
+        self.message = message
 
         self.create_datetime()
         self.create_work_hours()
-        self.create_message()
 
         line = f"{self.start_date},{self.start_time}," \
                f"{self.stop_date},{self.stop_time}," \
@@ -124,6 +122,3 @@ class Entry:
 
         time_delta = stop_time - start_time
         self.work_hours = time_delta
-
-    def create_message(self) -> None:
-        self.message = random.choice(self.messages)

--- a/src/setup_test_values/entry.py
+++ b/src/setup_test_values/entry.py
@@ -1,76 +1,129 @@
 import random
-from datetime import datetime
+from datetime import datetime, time
 
 
 class Entry:
     def __init__(self) -> None:
         self.start_date = ""
-        self.start_time = ""
+        self.start_time = None
 
         self.stop_date = ""
-        self.stop_time = ""
+        self.stop_time = None
 
         self.work_hours = ""
-
         self.message = ""
 
+        self.messages = []
         self.number = 0
 
         self.month = "Jan"
         self.year = "2022"
 
-    def create_datetime(self) -> None:
-        # CREATE HOURS
-        start_hour = random.randint(0, 11)
-        stop_hour = random.randint(start_hour, 12)
-
-        if self.number % 2 == 0:
-            # Second entry of day
-            start_hour += 11
-            stop_hour += 11
-
-        # Just leave them as they are
-        max_minutes = 58
-        max_seconds = 58
-
-        # CREATE MINUTES
-        start_minutes = random.randint(0, max_minutes)
-        stop_minutes = start_minutes + random.randint(1, 59 - start_minutes)
-
-        # CREATE SECONDS
-        start_seconds = random.randint(0, max_seconds)
-        stop_seconds = start_seconds + random.randint(1, 59 - start_seconds)
-
-        # CREATE DAY NUMBER
-        if self.number % 2 == 0:
-            date = int(self.number / 2)
-        else:
-            date = int((self.number + 1) / 2)
-
-        # BUILD FULL DATE/TIME
-        self.start_date = f"\"{self.month}, {date} {self.year}\""
-        self.start_time = f"{start_hour:02d}:{start_minutes:02d}:{start_seconds:02d}"
-
-        self.stop_date = self.start_date
-        self.stop_time = f"{stop_hour:02d}:{stop_minutes:02d}:{stop_seconds:02d}"
+        self.hours = {}
+        self.minutes = {}
+        self.seconds = {}
 
     def build(self, messages: list, number: int) -> str:
         self.number = number
+        self.messages = messages
 
         self.create_datetime()
         self.create_work_hours()
-        # BUILD MESSAGE
-        self.message = random.choice(messages)
+        self.create_message()
 
-        # BUILD FINAL ENTRY
-        line = f"{self.start_date},{self.start_time},{self.stop_date},{self.stop_time},{self.work_hours},{self.message}\n"
+        line = f"{self.start_date},{self.start_time}," \
+               f"{self.stop_date},{self.stop_time}," \
+               f"{self.work_hours},{self.message}" \
+               f"\n"
+
         return line
 
-    def create_work_hours(self) -> None:
-        time_format = "%H:%M:%S"
+    def create_datetime(self) -> None:
+        self.create_date()
+        self.create_time()
 
-        start_time = datetime.strptime(self.start_time, time_format)
-        stop_time = datetime.strptime(self.stop_time, time_format)
+    def create_date(self) -> None:
+        number = 0
+
+        # Count the date in double steps, makes two entries per day
+        if self.is_first_entry_of_day():
+            # 1 -> 1 + 1 / 2 = 1
+            # 3 -> 3 + 1 / 2 = 2
+            # 5 -> 5 + 1 / 2 = 3
+            number = (self.number + 1) / 2
+        elif self.is_second_entry_of_day():
+            # 2 -> 1
+            # 4 -> 2
+            # 6 -> 3
+            number = self.number / 2
+
+        date = int(number / 2)
+
+        self.start_date = f"\"{self.month}, {date} {self.year}\""
+        self.stop_date = self.start_date
+
+    def is_first_entry_of_day(self) -> bool:
+        return not self.is_second_entry_of_day()
+
+    def is_second_entry_of_day(self) -> bool:
+        return self.number % 2 == 0
+
+    def create_time(self) -> None:
+        # CREATE HOURS
+        hours = self.calculate_hours()
+        start_hour = hours["start"]
+        stop_hour = hours["stop"]
+
+        # CREATE MINUTES
+        minutes = self.calculate_minutes()
+        start_minutes = minutes["start"]
+        stop_minutes = minutes["stop"]
+
+        # CREATE SECONDS
+        seconds = self.calculate_seconds()
+        start_seconds = seconds["start"]
+        stop_seconds = seconds["stop"]
+
+        self.start_time = time(start_hour, start_minutes, start_seconds)
+        self.stop_time = time(stop_hour, stop_minutes, stop_seconds)
+
+    def calculate_hours(self) -> dict:
+        start_hour = random.randint(0, 11)
+        stop_hour = random.randint(start_hour, 12)
+
+        if self.is_second_entry_of_day():
+            # Second entry of day should be in the afternoon, cannot add 12 to prevent times like 24:10:00 -> invalid
+            start_hour += 11
+            stop_hour += 11
+
+        return {"start": start_hour, "stop": stop_hour}
+
+    @staticmethod
+    def calculate_minutes() -> dict:
+        # Needs to be this low to prevent times like 00:60:14 -> invalid
+        max_minutes = 58
+
+        start_minutes = random.randint(0, max_minutes)
+        stop_minutes = start_minutes + random.randint(1, 59 - start_minutes)
+
+        return {"start": start_minutes, "stop": stop_minutes}
+
+    @staticmethod
+    def calculate_seconds() -> dict:
+        # Needs to be this low to prevent times like 00:00:60 -> invalid
+        max_seconds = 58
+
+        start_seconds = random.randint(0, max_seconds)
+        stop_seconds = start_seconds + random.randint(1, 59 - start_seconds)
+
+        return {"start": start_seconds, "stop": stop_seconds}
+
+    def create_work_hours(self) -> None:
+        start_time = datetime.combine(datetime.min, self.start_time)
+        stop_time = datetime.combine(datetime.min, self.stop_time)
 
         time_delta = stop_time - start_time
         self.work_hours = time_delta
+
+    def create_message(self) -> None:
+        self.message = random.choice(self.messages)

--- a/src/setup_test_values/entry.py
+++ b/src/setup_test_values/entry.py
@@ -50,8 +50,6 @@ class Entry:
             # 4 -> 2
             # 6 -> 3
             number = self._number / 2
-        else:
-            number = 0
 
         date = int(number / 2)
 

--- a/src/setup_test_values/entry.py
+++ b/src/setup_test_values/entry.py
@@ -4,99 +4,99 @@ from datetime import datetime, time
 
 class Entry:
     def __init__(self) -> None:
-        self.start_date = ""
-        self.stop_date = ""
+        self._start_date = ""
+        self._stop_date = ""
 
-        self.start_time = None
-        self.stop_time = None
-        self.start_time_dict = {}
-        self.stop_time_dict = {}
+        self._start_time = None
+        self._stop_time = None
+        self._start_time_dict = {}
+        self._stop_time_dict = {}
 
-        self.work_hours = ""
-        self.message = ""
+        self._work_hours = ""
+        self._message = ""
 
-        self.number = 0
+        self._number = 0
 
-        self.month = "Jan"
-        self.year = "2022"
+        self._month = "Jan"
+        self._year = "2022"
 
     def build(self, message: str, number: int) -> str:
-        self.number = number
-        self.message = message
+        self._number = number
+        self._message = message
 
-        self.create_datetime()
-        self.create_work_hours()
+        self.__create_datetime()
+        self.__create_work_hours()
 
-        line = f"{self.start_date},{self.start_time}," \
-               f"{self.stop_date},{self.stop_time}," \
-               f"{self.work_hours},{self.message}" \
+        line = f"{self._start_date},{self._start_time}," \
+               f"{self._stop_date},{self._stop_time}," \
+               f"{self._work_hours},{self._message}" \
                f"\n"
 
         return line
 
-    def create_datetime(self) -> None:
-        self.create_date()
-        self.create_time()
+    def __create_datetime(self) -> None:
+        self.__create_date()
+        self.__create_time()
 
-    def create_date(self) -> None:
+    def __create_date(self) -> None:
         # Count the date in double steps, makes two entries per day
-        if self.is_first_entry_of_day():
+        if self.__is_first_entry_of_day():
             # 1 -> 1 + 1 / 2 = 1
             # 3 -> 3 + 1 / 2 = 2
             # 5 -> 5 + 1 / 2 = 3
-            number = (self.number + 1) / 2
-        elif self.is_second_entry_of_day():
+            number = (self._number + 1) / 2
+        elif self.__is_second_entry_of_day():
             # 2 -> 1
             # 4 -> 2
             # 6 -> 3
-            number = self.number / 2
+            number = self._number / 2
         else:
-           number = 0
+            number = 0
 
         date = int(number / 2)
 
-        self.start_date = f"\"{self.month}, {date} {self.year}\""
-        self.stop_date = self.start_date
+        self._start_date = f"\"{self._month}, {date} {self._year}\""
+        self._stop_date = self._start_date
 
-    def is_first_entry_of_day(self) -> bool:
-        return not self.is_second_entry_of_day()
+    def __is_first_entry_of_day(self) -> bool:
+        return not self.__is_second_entry_of_day()
 
-    def is_second_entry_of_day(self) -> bool:
-        return self.number % 2 == 0
+    def __is_second_entry_of_day(self) -> bool:
+        return self._number % 2 == 0
 
-    def create_time(self) -> None:
-        self.create_time_dict()
+    def __create_time(self) -> None:
+        self.__create_time_dict()
 
-        self.start_time = time(**self.start_time_dict)
-        self.stop_time = time(**self.stop_time_dict)
+        self._start_time = time(**self._start_time_dict)
+        self._stop_time = time(**self._stop_time_dict)
 
-    def create_time_dict(self) -> None:
-        hours = self.calculate_hours()
-        minutes = self.calculate_minutes()
-        seconds = self.calculate_seconds()
+    def __create_time_dict(self) -> None:
+        hours = self.__calculate_hours()
+        minutes = self.__calculate_minutes()
+        seconds = self.__calculate_seconds()
 
-        self.create_start_time_dict(hours, minutes, seconds)
-        self.create_stop_time_dict(hours, minutes, seconds)
+        self.__create_start_time_dict(hours, minutes, seconds)
+        self.__create_stop_time_dict(hours, minutes, seconds)
 
-    def create_start_time_dict(self, hours: dict, minutes: dict, seconds: dict) -> None:
+    def __create_start_time_dict(self, hours: dict, minutes: dict, seconds: dict) -> None:
         start_hour = hours["start"]
         start_minutes = minutes["start"]
         start_seconds = seconds["start"]
 
-        self.start_time_dict = {"hour": start_hour, "minute": start_minutes, "second": start_seconds}
+        self._start_time_dict = {"hour": start_hour, "minute": start_minutes, "second": start_seconds}
 
-    def create_stop_time_dict(self, hours: dict, minutes: dict, seconds: dict) -> None:
+    def __create_stop_time_dict(self, hours: dict, minutes: dict, seconds: dict) -> None:
         stop_hour = hours["stop"]
         stop_minutes = minutes["stop"]
         stop_seconds = seconds["stop"]
 
-        self.stop_time_dict = {"hour": stop_hour, "minute": stop_minutes, "second": stop_seconds}
+        self._stop_time_dict = {"hour": stop_hour, "minute": stop_minutes, "second": stop_seconds}
 
-    def calculate_hours(self) -> dict:
+    def __calculate_hours(self) -> dict:
         start_hour = random.randint(0, 11)
         stop_hour = random.randint(start_hour, 12)
 
-        if self.is_second_entry_of_day():
+        if self.__is_second_entry_of_day():
             # Second entry of day should be in the afternoon, cannot add 12 to prevent times like 24:10:00 -> invalid
             start_hour += 11
             stop_hour += 11
@@ -104,7 +104,7 @@ class Entry:
         return {"start": start_hour, "stop": stop_hour}
 
     @staticmethod
-    def calculate_minutes() -> dict:
+    def __calculate_minutes() -> dict:
         # Needs to be this low to prevent times like 00:60:14 -> invalid
         max_minutes = 58
 
@@ -114,7 +114,7 @@ class Entry:
         return {"start": start_minutes, "stop": stop_minutes}
 
     @staticmethod
-    def calculate_seconds() -> dict:
+    def __calculate_seconds() -> dict:
         # Needs to be this low to prevent times like 00:00:60 -> invalid
         max_seconds = 58
 
@@ -123,9 +123,9 @@ class Entry:
 
         return {"start": start_seconds, "stop": stop_seconds}
 
-    def create_work_hours(self) -> None:
-        start_time = datetime.combine(datetime.min, self.start_time)
-        stop_time = datetime.combine(datetime.min, self.stop_time)
+    def __create_work_hours(self) -> None:
+        start_time = datetime.combine(datetime.min, self._start_time)
+        stop_time = datetime.combine(datetime.min, self._stop_time)
 
         time_delta = stop_time - start_time
-        self.work_hours = time_delta
+        self._work_hours = time_delta

--- a/src/setup_test_values/entry.py
+++ b/src/setup_test_values/entry.py
@@ -1,0 +1,73 @@
+import random
+from datetime import datetime
+
+
+class Entry:
+    def __init__(self) -> None:
+        self.start_date = ""
+        self.start_time = ""
+
+        self.stop_date = ""
+        self.stop_time = ""
+
+        self.work_hours = ""
+
+        self.message = ""
+
+        self.line = ""
+        self.number = 0
+
+        self.month = "Jan"
+        self.year = "2022"
+
+    def create_start_date(self) -> None:
+        # Just leave it as it is
+        max_hours = 23
+        max_minutes = 58
+        max_seconds = 58
+
+        # CREATE HOURS
+        start_hour = random.randint(0, 11)
+        stop_hour = random.randint(start_hour, 12)
+
+        if self.number % 2 == 0:
+            # Second entry of day
+            start_hour += 11
+            stop_hour += 11
+
+        # CREATE MINUTES
+        start_minutes = random.randint(0, max_minutes)
+        stop_minutes = start_minutes + random.randint(1, 59 - start_minutes)
+
+        # CREATE SECONDS
+        start_seconds = random.randint(0, max_seconds)
+        stop_seconds = start_seconds + random.randint(1, 59 - start_seconds)
+
+        # CREATE DAY NUMBER
+        if self.number % 2 == 0:
+            date = int(self.number / 2)
+        else:
+            date = int((self.number + 1) / 2)
+
+        # BUILD FULL DATE/TIME
+        self.start_date = f"\"{self.month}, {date} {self.year}\""
+        self.start_time = f"{start_hour:02d}:{start_minutes:02d}:{start_seconds:02d}"
+
+        self.stop_date = self.start_date
+        self.stop_time = f"{stop_hour:02d}:{stop_minutes:02d}:{stop_seconds:02d}"
+
+    def build(self, messages: list, number: int) -> str:
+        self.number = number
+
+        self.create_start_date()
+
+        # BUILD WORK HOURS
+        date_format = "%H:%M:%S"
+        self.work_hours = datetime.strptime(self.stop_time, date_format) - datetime.strptime(self.start_time, date_format)
+
+        # BUILD MESSAGE
+        self.message = random.choice(messages)
+
+        # BUILD FINAL ENTRY
+        self.line = f"{self.start_date},{self.start_time},{self.stop_date},{self.stop_time},{self.work_hours},{self.message}\n"
+        return self.line

--- a/src/setup_test_values/entry.py
+++ b/src/setup_test_values/entry.py
@@ -14,18 +14,12 @@ class Entry:
 
         self.message = ""
 
-        self.line = ""
         self.number = 0
 
         self.month = "Jan"
         self.year = "2022"
 
-    def create_start_date(self) -> None:
-        # Just leave it as it is
-        max_hours = 23
-        max_minutes = 58
-        max_seconds = 58
-
+    def create_datetime(self) -> None:
         # CREATE HOURS
         start_hour = random.randint(0, 11)
         stop_hour = random.randint(start_hour, 12)
@@ -34,6 +28,10 @@ class Entry:
             # Second entry of day
             start_hour += 11
             stop_hour += 11
+
+        # Just leave them as they are
+        max_minutes = 58
+        max_seconds = 58
 
         # CREATE MINUTES
         start_minutes = random.randint(0, max_minutes)
@@ -59,15 +57,20 @@ class Entry:
     def build(self, messages: list, number: int) -> str:
         self.number = number
 
-        self.create_start_date()
-
-        # BUILD WORK HOURS
-        date_format = "%H:%M:%S"
-        self.work_hours = datetime.strptime(self.stop_time, date_format) - datetime.strptime(self.start_time, date_format)
-
+        self.create_datetime()
+        self.create_work_hours()
         # BUILD MESSAGE
         self.message = random.choice(messages)
 
         # BUILD FINAL ENTRY
-        self.line = f"{self.start_date},{self.start_time},{self.stop_date},{self.stop_time},{self.work_hours},{self.message}\n"
-        return self.line
+        line = f"{self.start_date},{self.start_time},{self.stop_date},{self.stop_time},{self.work_hours},{self.message}\n"
+        return line
+
+    def create_work_hours(self) -> None:
+        time_format = "%H:%M:%S"
+
+        start_time = datetime.strptime(self.start_time, time_format)
+        stop_time = datetime.strptime(self.stop_time, time_format)
+
+        time_delta = stop_time - start_time
+        self.work_hours = time_delta

--- a/src/setup_test_values/setup_test_values.py
+++ b/src/setup_test_values/setup_test_values.py
@@ -1,3 +1,5 @@
+import random
+
 from src.csv import CSVHandler
 from .entry import Entry
 
@@ -39,4 +41,5 @@ class SetupTestValues:
         return entries
 
     def build_entry(self, number: int) -> str:
-        return self.entry.build(self.messages, number)
+        message = random.choice(self.messages)
+        return self.entry.build(message, number)

--- a/src/setup_test_values/setup_test_values.py
+++ b/src/setup_test_values/setup_test_values.py
@@ -16,7 +16,7 @@ class SetupTestValues:
             "Fixing bugs", "Adding tests", "Refactoring"
         ]
 
-        self.entry = Entry()
+        self.__entry = Entry()
 
     def set_number_of_entries(self, new_number: int):
         if new_number < 0:
@@ -42,4 +42,4 @@ class SetupTestValues:
 
     def __build_entry(self, number: int) -> str:
         message = random.choice(self.__messages)
-        return self.entry.build(message, number)
+        return self.__entry.build(message, number)

--- a/src/setup_test_values/setup_test_values.py
+++ b/src/setup_test_values/setup_test_values.py
@@ -1,11 +1,7 @@
 from datetime import datetime
 import random
 
-import click
-import num2words
-
-from .csv import CSVHandler
-from src.console_logger.console_logger import info, warn
+from src.csv import CSVHandler
 
 
 class SetupTestValues:
@@ -32,78 +28,57 @@ class SetupTestValues:
     def setup(self) -> None:
         with open(self.csv_handler.tracker_file, "w") as f:
             f.write(self.header())
-            f.write(self.test_value_lines())
+            f.write(self.entries())
 
     def header(self) -> str:
         return ",".join(self.csv_handler.column_names) + "\n"
 
-    def test_value_lines(self) -> str:
-        lines = ""
+    def entries(self) -> str:
+        entries = ""
 
         for i in range(1, self.number_of_entries + 1):
-            lines += self.build_test_value_line(i)
+            entries += self.build_entry(i)
 
-        return lines
+        return entries
 
-    def build_test_value_line(self, number: int) -> str:
+    def build_entry(self, number: int) -> str:
+        # CREATE HOURS
         start_hour = number
         stop_hour = number + random.choice([0, 1])
 
         # Just leave it as it is
+        max_start_minutes = 58
+        # Just leave it as it is
         max_start_seconds = 58
 
-        start_minutes = random.randint(0, max_start_seconds)
+        # CREATE MINUTES
+        start_minutes = random.randint(0, max_start_minutes)
         stop_minutes = start_minutes + random.randint(1, 59 - start_minutes)
 
+        # CREATE SECONDS
         start_seconds = random.randint(0, max_start_seconds)
         stop_seconds = start_seconds + random.randint(1, 59 - start_seconds)
 
+        # CREATE DAY NUMBER
         if number % 2 == 0:
             date = int(number / 2)
         else:
             date = int((number + 1) / 2)
 
+        # BUILD FULL DATE/TIME
         start_date = f"\"{self.month}, {date} {self.year}\""
         start_time = f"{start_hour:02d}:{start_minutes:02d}:{start_seconds:02d}"
 
         stop_date = start_date
         stop_time = f"{stop_hour:02d}:{stop_minutes:02d}:{stop_seconds:02d}"
 
+        # BUILD WORK HOURS
         date_format = "%H:%M:%S"
         work_hours = datetime.strptime(stop_time, date_format) - datetime.strptime(start_time, date_format)
 
+        # BUILD MESSAGE
         message = random.choice(self.messages)
 
+        # BUILD FINAL ENTRY
         line = f"{start_date},{start_time},{stop_date},{stop_time},{work_hours},{message}\n"
         return line
-
-
-def handler_invalid_number_of_entries() -> None:
-    warn("The number of entries cannot be negative. Please specify a value greater than or equal zero.\n"
-         "EXIT")
-    exit(-1)
-
-
-@click.command()
-@click.option("-e", "--entries", help="Number of entries to create", type=int, default=4)
-def setup_test_values(entries: int) -> None:
-    set_upper = SetupTestValues()
-
-    try:
-        set_upper.set_number_of_entries(entries)
-    except ValueError:
-        handler_invalid_number_of_entries()
-
-    set_upper.setup()
-
-    entries_as_word = num2words.num2words(entries)
-    message = "\nSuccesfully setup"
-    if entries == 1:
-        info(f"{message} one entry.")
-    else:
-        info(f"{message} {entries_as_word} entries.")
-    info("OK")
-
-
-if __name__ == "__main__":  # pragma: no cover
-    setup_test_values()

--- a/src/setup_test_values/setup_test_values.py
+++ b/src/setup_test_values/setup_test_values.py
@@ -1,7 +1,5 @@
-from datetime import datetime
-import random
-
 from src.csv import CSVHandler
+from .entry import Entry
 
 
 class SetupTestValues:
@@ -11,13 +9,12 @@ class SetupTestValues:
 
         self.number_of_entries = 4
 
-        self.month = "Jan"
-        self.year = "2022"
-
         self.messages = [
             "", "Working on Tracker", "Developing new features",
             "Fixing bugs", "Adding tests", "Refactoring"
         ]
+
+        self.entry = Entry()
 
     def set_number_of_entries(self, new_number: int):
         if new_number < 0:
@@ -42,43 +39,4 @@ class SetupTestValues:
         return entries
 
     def build_entry(self, number: int) -> str:
-        # CREATE HOURS
-        start_hour = number
-        stop_hour = number + random.choice([0, 1])
-
-        # Just leave it as it is
-        max_start_minutes = 58
-        # Just leave it as it is
-        max_start_seconds = 58
-
-        # CREATE MINUTES
-        start_minutes = random.randint(0, max_start_minutes)
-        stop_minutes = start_minutes + random.randint(1, 59 - start_minutes)
-
-        # CREATE SECONDS
-        start_seconds = random.randint(0, max_start_seconds)
-        stop_seconds = start_seconds + random.randint(1, 59 - start_seconds)
-
-        # CREATE DAY NUMBER
-        if number % 2 == 0:
-            date = int(number / 2)
-        else:
-            date = int((number + 1) / 2)
-
-        # BUILD FULL DATE/TIME
-        start_date = f"\"{self.month}, {date} {self.year}\""
-        start_time = f"{start_hour:02d}:{start_minutes:02d}:{start_seconds:02d}"
-
-        stop_date = start_date
-        stop_time = f"{stop_hour:02d}:{stop_minutes:02d}:{stop_seconds:02d}"
-
-        # BUILD WORK HOURS
-        date_format = "%H:%M:%S"
-        work_hours = datetime.strptime(stop_time, date_format) - datetime.strptime(start_time, date_format)
-
-        # BUILD MESSAGE
-        message = random.choice(self.messages)
-
-        # BUILD FINAL ENTRY
-        line = f"{start_date},{start_time},{stop_date},{stop_time},{work_hours},{message}\n"
-        return line
+        return self.entry.build(self.messages, number)

--- a/src/setup_test_values/setup_test_values.py
+++ b/src/setup_test_values/setup_test_values.py
@@ -6,12 +6,12 @@ from .entry import Entry
 
 class SetupTestValues:
     def __init__(self) -> None:
-        self.csv_handler = CSVHandler.CSVHandler()
-        self.csv_handler.create_files_folder_if_not_exists()
+        self.__csv_handler = CSVHandler.CSVHandler()
+        self.__csv_handler.create_files_folder_if_not_exists()
 
-        self.number_of_entries = 4
+        self._number_of_entries = 4
 
-        self.messages = [
+        self.__messages = [
             "", "Working on Tracker", "Developing new features",
             "Fixing bugs", "Adding tests", "Refactoring"
         ]
@@ -22,24 +22,24 @@ class SetupTestValues:
         if new_number < 0:
             raise ValueError("The number of entries to create cannot be negative.")
 
-        self.number_of_entries = new_number
+        self._number_of_entries = new_number
 
     def setup(self) -> None:
-        with open(self.csv_handler.tracker_file, "w") as f:
-            f.write(self.header())
-            f.write(self.entries())
+        with open(self.__csv_handler.tracker_file, "w") as f:
+            f.write(self.__header())
+            f.write(self.__entries())
 
-    def header(self) -> str:
-        return ",".join(self.csv_handler.column_names) + "\n"
+    def __header(self) -> str:
+        return ",".join(self.__csv_handler.column_names) + "\n"
 
-    def entries(self) -> str:
+    def __entries(self) -> str:
         entries = ""
 
-        for i in range(1, self.number_of_entries + 1):
-            entries += self.build_entry(i)
+        for i in range(1, self._number_of_entries + 1):
+            entries += self.__build_entry(i)
 
         return entries
 
-    def build_entry(self, number: int) -> str:
-        message = random.choice(self.messages)
+    def __build_entry(self, number: int) -> str:
+        message = random.choice(self.__messages)
         return self.entry.build(message, number)

--- a/tests/test_click_commands/CommandBaseTestingClass.py
+++ b/tests/test_click_commands/CommandBaseTestingClass.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 from src.main import cli, add_subcommands_to_cli
 from src.csv.CSVHandler import CSVHandler
-from src.setup_test_values import SetupTestValues
+from src.setup_test_values.setup_test_values import SetupTestValues
 
 
 class CommandBaseTestingClass(unittest.TestCase):

--- a/tests/test_click_commands/CommandBaseTestingClass.py
+++ b/tests/test_click_commands/CommandBaseTestingClass.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 
 from src.main import cli, add_subcommands_to_cli
 from src.csv.CSVHandler import CSVHandler
+from src.setup_test_values import SetupTestValues
 
 
 class CommandBaseTestingClass(unittest.TestCase):
@@ -13,6 +14,7 @@ class CommandBaseTestingClass(unittest.TestCase):
         self.result = None
 
         self.csv_handler = CSVHandler()
+        self.set_upper = SetupTestValues()
 
         add_subcommands_to_cli()
 
@@ -29,3 +31,6 @@ class CommandBaseTestingClass(unittest.TestCase):
         except FileNotFoundError:
             # File is not existing, that's good, nothing to do for us.
             pass
+
+    def setup_test_values(self) -> None:
+        self.set_upper.setup()

--- a/tests/test_click_commands/test_log/test_log.py
+++ b/tests/test_click_commands/test_log/test_log.py
@@ -1,7 +1,6 @@
 import unittest
 
 from ..CommandBaseTestingClass import CommandBaseTestingClass
-from src.setup_test_values import setup_test_values
 
 
 class TestLog(CommandBaseTestingClass):
@@ -10,7 +9,7 @@ class TestLog(CommandBaseTestingClass):
 
     def test_logging_a_specific_entry(self) -> None:
         self.clean_and_init_tracker_file()
-        setup_test_values()
+        self.setup_test_values()
 
         self.run_cli(["log", "-i 1"])
 
@@ -18,7 +17,7 @@ class TestLog(CommandBaseTestingClass):
 
     def test_logging_a_sepcific_entry_with_unknown_id(self) -> None:
         self.clean_and_init_tracker_file()
-        setup_test_values()
+        self.setup_test_values()
 
         self.check_for_not_matching_id_of_date(-1)
         self.check_for_not_matching_id_of_date(0)
@@ -57,7 +56,7 @@ class TestLog(CommandBaseTestingClass):
     def test_logging_with_multiple_grouped_entries(self) -> None:
         self.clean_and_init_tracker_file()
 
-        setup_test_values()
+        self.setup_test_values()
 
         total_dates = 2
         self.check_for_log_message(total_dates)

--- a/tests/test_csv/CSVBaseTestingClass.py
+++ b/tests/test_csv/CSVBaseTestingClass.py
@@ -4,11 +4,13 @@ import os
 import pandas
 
 from src.csv.CSVHandler import CSVHandler
+from src.setup_test_values import SetupTestValues
 
 
 class CSVBaseTestingClass(unittest.TestCase):
     def setUp(self) -> None:
         self.csv_handler = CSVHandler()
+        self.set_upper = SetupTestValues()
 
     def check_for_correct_column_names(self) -> None:
         self.assertTrue(self.columns_names_are_correct())
@@ -41,3 +43,6 @@ class CSVBaseTestingClass(unittest.TestCase):
     def get_contents_of_tracker_file(self) -> pandas.DataFrame:
         data_frame = pandas.read_csv(self.csv_handler.tracker_file)
         return data_frame
+
+    def setup_test_values(self) -> None:
+        self.set_upper.setup()

--- a/tests/test_csv/CSVBaseTestingClass.py
+++ b/tests/test_csv/CSVBaseTestingClass.py
@@ -4,7 +4,7 @@ import os
 import pandas
 
 from src.csv.CSVHandler import CSVHandler
-from src.setup_test_values import SetupTestValues
+from src.setup_test_values.setup_test_values import SetupTestValues
 
 
 class CSVBaseTestingClass(unittest.TestCase):

--- a/tests/test_handler/test_entry_handler/test_base_entry_handler_class.py
+++ b/tests/test_handler/test_entry_handler/test_base_entry_handler_class.py
@@ -2,7 +2,6 @@ import unittest
 
 import pandas
 
-from src.setup_test_values import setup_test_values
 from src.csv.CSVAttributes import CSVAttributes
 from src.handler.entry_handler.BaseEntryHandlerClass import BaseEntryHandlerClass
 
@@ -24,7 +23,7 @@ class TestBaseEntryHandlerClass(CSVBaseTestingClass):
 
     def test_getting_filled_data(self) -> None:
         self.clean_and_init_tracker_file()
-        setup_test_values()
+        self.setup_test_values()
 
         self.data = self.base_entry_handler.get_data()
 
@@ -43,7 +42,7 @@ class TestBaseEntryHandlerClass(CSVBaseTestingClass):
 
     def test_grouping_entries_by_date_with_filled_data(self) -> None:
         self.clean_and_init_tracker_file()
-        setup_test_values()
+        self.setup_test_values()
 
         self.base_entry_handler.data = self.base_entry_handler.get_data()
         entries_grouped_by_date = self.base_entry_handler.group_entries_by_date()

--- a/tests/test_handler/test_entry_handler/test_entry_handler.py
+++ b/tests/test_handler/test_entry_handler/test_entry_handler.py
@@ -2,8 +2,6 @@ import unittest
 
 import pandas
 
-from src.setup_test_values import setup_test_values
-
 from src.handler.entry_handler.EntryHandler import EntryHandler
 from src.exceptions.InvalidIDOfDateException import InvalidIDOfDateException
 
@@ -18,7 +16,7 @@ class TestEntryHandler(CSVBaseTestingClass):
 
     def test_logging_entries_of_specific_date(self) -> None:
         self.clean_and_init_tracker_file()
-        setup_test_values()
+        self.setup_test_values()
 
         entries = self.entry_handler.get_entries_of_specific_date(1)
         date = entries[0]
@@ -41,7 +39,7 @@ class TestEntryHandler(CSVBaseTestingClass):
 
     def test_logging_entries_of_specific_date_with_unknown_id(self) -> None:
         self.clean_and_init_tracker_file()
-        setup_test_values()
+        self.setup_test_values()
 
         self.check_for_invalid_id_of_date_exception(0)
         self.check_for_invalid_id_of_date_exception(-1)

--- a/tests/test_setting_up_test_values.py
+++ b/tests/test_setting_up_test_values.py
@@ -1,6 +1,6 @@
 import unittest
 
-from src.setup_test_values import SetupTestValues
+from src.setup_test_values.setup_test_values import SetupTestValues
 
 from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
 

--- a/tests/test_setting_up_test_values.py
+++ b/tests/test_setting_up_test_values.py
@@ -61,5 +61,5 @@ class TestSettingUpTestValues(CSVBaseTestingClass):
         self.assertRaises(ValueError, self.set_upper.set_number_of_entries, -1)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_setting_up_test_values.py
+++ b/tests/test_setting_up_test_values.py
@@ -1,6 +1,6 @@
 import unittest
 
-from src.setup_test_values import setup_test_values
+from src.setup_test_values import SetupTestValues
 
 from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
 
@@ -8,10 +8,11 @@ from tests.test_csv.CSVBaseTestingClass import CSVBaseTestingClass
 class TestSettingUpTestValues(CSVBaseTestingClass):
     def setUp(self) -> None:
         super(TestSettingUpTestValues, self).setUp()
+        self.set_upper = SetupTestValues()
 
     def test_creating_the_header(self):
         self.clean_and_init_tracker_file()
-        setup_test_values()
+        self.set_upper.setup()
 
         with open(self.csv_handler.tracker_file, "r") as f:
             header_actual = f.readline().strip()
@@ -19,8 +20,45 @@ class TestSettingUpTestValues(CSVBaseTestingClass):
 
             self.assertEqual(header_exspected, header_actual)
 
-    def test_number_of_created_items(self):
-        pass
+    def test_number_of_entries_to_create(self):
+        self.clean_and_init_tracker_file()
+        self.set_upper.setup()
+
+        self.check_if_number_of_entries_have_been_created()
+
+    def check_if_number_of_entries_have_been_created(self):
+        with open(self.csv_handler.tracker_file, "r") as f:
+            content = f.read().strip()
+            number_of_lines = len(content.split("\n"))
+
+            # Remove the line for the header
+            number_of_entries = number_of_lines - 1
+            self.assertEqual(self.set_upper.number_of_entries, number_of_entries)
+
+    def test_creating_no_entries(self):
+        self.clean_and_init_tracker_file()
+
+        self.check_for_changed_number_of_entries(0)
+
+    def test_changing_the_number_of_entries_to_create(self):
+        self.clean_and_init_tracker_file()
+
+        for i in range(1, 21):
+            self.check_for_changed_number_of_entries(i)
+
+    def check_for_changed_number_of_entries(self, number_of_entries: int):
+        self.set_upper.set_number_of_entries(number_of_entries)
+        self.set_upper.setup()
+
+        self.check_if_number_of_entries_have_been_created()
+
+        # Reset the values for the set upper
+        self.set_upper.__init__()
+
+    def test_invalid_number_of_entries_to_create(self):
+        self.clean_and_init_tracker_file()
+
+        self.assertRaises(ValueError, self.set_upper.set_number_of_entries, -1)
 
 
 if __name__ == "__main__":

--- a/tests/test_setting_up_test_values.py
+++ b/tests/test_setting_up_test_values.py
@@ -33,7 +33,7 @@ class TestSettingUpTestValues(CSVBaseTestingClass):
 
             # Remove the line for the header
             number_of_entries = number_of_lines - 1
-            self.assertEqual(self.set_upper.number_of_entries, number_of_entries)
+            self.assertEqual(self.set_upper._number_of_entries, number_of_entries)
 
     def test_creating_no_entries(self):
         self.clean_and_init_tracker_file()


### PR DESCRIPTION
Refactor the logic of the command `make setup`. It is now possible to specify the number of entries being created by typing `make setup entries=6` (to create six entries) and the algorithm is choosing randomly between a list of messages.

I refactored the logic a lot to make the functions small and easy to understand.
There are also protected `self._variable_name` and private `self.__variable_name` variables and functions which I'll add to the rest of the project later.

- [X] Added tests verifying the change